### PR TITLE
BUG FIX - RGB Tensor returns correct shape and dimension

### DIFF
--- a/src/roc_pybuffer.cpp
+++ b/src/roc_pybuffer.cpp
@@ -163,8 +163,9 @@ int BufferInterface::LoadDLPack(std::vector<size_t>& _shape, std::vector<size_t>
     }
     
     // Convert strides
-    m_dlTensor->strides = new int64_t[m_dlTensor->ndim];
-    for (int i = 0; i < m_dlTensor->ndim; ++i) {
+    int strides_dim = _stride.size();
+    m_dlTensor->strides = new int64_t[strides_dim];
+    for (int i = 0; i < strides_dim; ++i) {
         m_dlTensor->strides[i] = _stride[i];
         if (m_dlTensor->strides[i] % itemSizeDT != 0) {
             throw std::runtime_error("Stride must be a multiple of the element size in bytes");

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -226,8 +226,8 @@ py::object PyRocVideoDecoder::PyGetFrameRgb(PyPacketData& packet, int rgb_format
             uint32_t height = GetHeight();
             uint32_t surf_stride = post_proc->GetRgbStride(e_output_format, surf_info);
             std::string type_str(static_cast<const char*>("|u1"));
-            std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width)};
-            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1};
+            std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width), 3}; // 3 rgb channels
+            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1, 0}; // python assumes same dim for both shape & strides
             packet.extBuf->LoadDLPack(shape, stride, type_str, (void *)frame_ptr_rgb);
         }
     }


### PR DESCRIPTION
This PR makes an RGB Tensor size appear as [2016, 4023, 3] instead of [2016, 4032] in python call (for example).
It fixes this issue discovered by Joshua Heiser, it works/fixed with the provided a video as a test.