### PR TITLE
build fix - cmake module not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "cmake"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
@kiritigowda this resolves the issue we saw with cmake module not found for build