### PR TITLE
Add build options for user - specific ASIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,16 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+message("-- ${Cyan}     -D ROCPYDECODE_AMDGPU_TARGET=${ROCPYDECODE_AMDGPU_TARGET} [Build for specific AMD GPUs]${ColourReset}")
+
 # set amdgpu targets with vcn support
-set(DEFAULT_AMDGPU_TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102")
+option(ROCPYDECODE_AMDGPU_TARGET "AMD GPU target ASIC to build rocPyDecode" "")
+
+if (ROCPYDECODE_AMDGPU_TARGET)
+    set(DEFAULT_AMDGPU_TARGETS "${ROCPYDECODE_AMDGPU_TARGET}" CACHE STRING "Specific machine types for library to target")
+else()
+    set(DEFAULT_AMDGPU_TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102")
+endif()
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
 
 find_package(HIP QUIET)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ python3 rocPyDecode-requirements.py
 
 ## rocPyDecode install
 
+>[!NOTE]
+> For developers using a particular AMD GPU as target ASIC, set the below environment variable for a fast build
+> ``` export ROCPYDECODE_AMDGPU_TARGET=<gfx taregt name> ```
+
 ### using bare-metal
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ python3 rocPyDecode-requirements.py
 ## rocPyDecode install
 
 >[!NOTE]
-> For developers using a particular AMD GPU as target ASIC, set the below environment variable for a fast build
+> For developers using a particular AMD GPU as target ASIC, set the below environment variable for a fast build. \
 > ``` export ROCPYDECODE_AMDGPU_TARGET=<gfx taregt name> ```
 
 ### using bare-metal

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 rocPyDecode-requirements.py
 
 >[!NOTE]
 > For developers using a particular AMD GPU as target ASIC, set the below environment variable for a fast build. \
-> ``` export ROCPYDECODE_AMDGPU_TARGET=<gfx taregt name> ```
+> ``` export ROCPYDECODE_AMDGPU_TARGET=<gfx target name> ```
 
 ### using bare-metal
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,12 @@ class custom_bdist_wheel(_bdist_wheel):
 # Call CMake to configure and build the project
 build_dir = os.path.join(os.getcwd(), 'build')
 os.makedirs(build_dir, exist_ok=True)
-cmake_args=["cmake", ".", "-B"+build_dir, "-H"+os.getcwd()]
+#check for environment variable - developer option
+amdgpu_target = os.environ.get('ROCPYDECODE_GPU_TARGET')
+if(amdgpu_target == None):
+    cmake_args=["cmake", ".", "-B"+build_dir, "-H"+os.getcwd()]
+else:
+    cmake_args=["cmake", ".", "-B"+build_dir, "-H"+os.getcwd(), "-DROCPYDECODE_GPU_TARGET="+amdgpu_target]
 subprocess.check_call(cmake_args,cwd=os.getcwd())
 
 # Invoke cmake --build to build the project


### PR DESCRIPTION
Adding an environment variable for developers to set while building rocPyDecode for a specific target ASIC.
```
export ROCPYDECODE_AMDGPU_TARGET=<gfx target name> 
```
Addresses #64 