### PR TITLE
Using GetCaps and adding 'GPU-not supported' msg

### DIFF
--- a/pyRocVideoDecode/decoder.py
+++ b/pyRocVideoDecode/decoder.py
@@ -145,3 +145,6 @@ class decoder(object):
             return self.viddec.GetDecoderSessionOverHead(session_id)
         else:
             return None
+
+    def IsCodecSupported(self, device_id, codec_id, bit_depth):
+        return self.viddec.IsCodecSupported(device_id, codec_id, bit_depth)

--- a/pyRocVideoDecode/demuxer.py
+++ b/pyRocVideoDecode/demuxer.py
@@ -42,6 +42,7 @@ class demuxer(object):
 
     def SeekFrame(self, frame_number, seek_mode, seek_criteria):
          return self.vidmux.SeekFrame(frame_number, seek_mode, seek_criteria)
-    
 
-     
+    def GetBitDepth(self):
+        return self.vidmux.GetBitDepth()
+

--- a/samples/videodecode.py
+++ b/samples/videodecode.py
@@ -40,6 +40,11 @@ def Decoder(
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/samples/videodecodemem.py
+++ b/samples/videodecodemem.py
@@ -40,6 +40,11 @@ def Decoder(
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/samples/videodecodeperf.py
+++ b/samples/videodecodeperf.py
@@ -38,6 +38,11 @@ def DecProc(input_file_path, device_id, p_frames, p_fps):
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/samples/videodecodergb.py
+++ b/samples/videodecodergb.py
@@ -35,6 +35,11 @@ def Decoder(
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/samples/videodecodetorch.py
+++ b/samples/videodecodetorch.py
@@ -35,6 +35,11 @@ def Decoder(
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/samples/videodecodetorch_resnet50.py
+++ b/samples/videodecodetorch_resnet50.py
@@ -50,6 +50,11 @@ def Decoder(
     # Get GPU device information
     cfg = viddec.GetGpuInfo()
 
+    # check if codec is supported
+    if (viddec.IsCodecSupported(device_id, codec_id, demuxer.GetBitDepth()) == False):
+        print("ERROR: Codec is not supported on this GPU " + cfg.device_name)
+        exit()
+
     #  print some GPU info out
     print("\ninfo: Input file: " +
           input_file_path +

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -50,6 +50,7 @@ void PyRocVideoDecoderInitializer(py::module& m) {
         .def("InitMd5",&PyRocVideoDecoder::PyInitMd5)
         .def("FinalizeMd5",&PyRocVideoDecoder::PyFinalizeMd5)
         .def("UpdateMd5ForFrame",&PyRocVideoDecoder::PyUpdateMd5ForFrame)
+        .def("IsCodecSupported",&PyRocVideoDecoder::PyCodecSupported)
 // TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)
 #if OVERHEAD_SUPPORT
         .def("AddDecoderSessionOverHead",&PyRocVideoDecoder::PyAddDecoderSessionOverHead)
@@ -388,6 +389,12 @@ py::int_ PyRocVideoDecoder::PyGetFrameSize() {
 // for python binding
 py::int_ PyRocVideoDecoder::PyGetStride() {
     return py::int_(static_cast<int>(GetSurfaceStride()));
+}
+
+// for python binding
+py::object PyRocVideoDecoder::PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth) {
+    bool ret = CodecSupported(device_id, codec_id, bit_depth);
+    return py::cast(ret);
 }
 
 // TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)

--- a/src/roc_pyvideodecode.h
+++ b/src/roc_pyvideodecode.h
@@ -106,6 +106,10 @@ class PyRocVideoDecoder : public RocVideoDecoder {
 
         // for python binding
         py::object PySetReconfigParams(int flush_mode, std::string& output_file_name_in);
+
+        // for python binding
+        py::object PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth);
+
 #if OVERHEAD_SUPPORT
         // Session overhead refers to decoder initialization and deinitialization time
         py::object PyAddDecoderSessionOverHead(int session_id, double duration);

--- a/src/roc_pyvideodemuxer.cpp
+++ b/src/roc_pyvideodemuxer.cpp
@@ -31,7 +31,8 @@ void PyVideoDemuxerInitializer(py::module& m) {
         .def(py::init<PyFileStreamProvider *>())
         .def("GetCodecId",&PyVideoDemuxer::GetCodecId,"Get Codec ID")
         .def("DemuxFrame",&PyVideoDemuxer::DemuxFrame)
-        .def("SeekFrame",&PyVideoDemuxer::SeekFrame);
+        .def("SeekFrame",&PyVideoDemuxer::SeekFrame)
+        .def("GetBitDepth",&PyVideoDemuxer::PyGetBitDepth);
 }
 
 void PyVideoStreamProviderInitializer(py::module& m) {
@@ -95,4 +96,8 @@ shared_ptr<PyPacketData> PyVideoDemuxer::SeekFrame(int frame_number, int seek_mo
 
 int PyVideoDemuxer::GetCodecId() {
     return GetCodecID();
+}
+
+uint32_t PyVideoDemuxer::PyGetBitDepth() {
+    return GetBitDepth();
 }

--- a/src/roc_pyvideodemuxer.h
+++ b/src/roc_pyvideodemuxer.h
@@ -49,6 +49,7 @@ class PyVideoDemuxer : public VideoDemuxer {
         std::shared_ptr<PyPacketData> DemuxFrame();
         std::shared_ptr<PyPacketData> SeekFrame(int frame_number, int seek_mode, int seek_criteria);
         int GetCodecId();
+        uint32_t PyGetBitDepth();
 };
 
 /**


### PR DESCRIPTION
rocPyDecode determines at runtime if the AMD VCNs support the codec associated with the media before decoding it, utilizing rocDecode GetCaps API, displaying a message if not supported and exit gracefully. 