### PR TITLE
Fixing build error message that shows "No module named pip"

### DIFF
--- a/rocPyDecode-requirements.py
+++ b/rocPyDecode-requirements.py
@@ -180,4 +180,8 @@ elif "redhat" in platfromInfo:
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ coreRPMPackages[i]))
 
-print("\rocPyDecode Dependencies Installed with rocPyDecode-setup.py V-"+__version__+"\n")
+# add python-hip for perf tests (moved from CMakeLists.txt of the 'samples' folder)
+ERROR_CHECK(os.system('python3 -m pip install --upgrade pip'))
+ERROR_CHECK(os.system('python3 -m pip install -i https://test.pypi.org/simple hip-python'))
+
+print("rocPyDecode Dependencies Installed with rocPyDecode-requirements.py V-"+__version__+"\n")

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -27,9 +27,9 @@ find_package(Python3 QUIET)
 
 # rocPyDecode tests
 if(Python3_FOUND)
-    # add python-hip for perf tests
-    execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade pip)
-    execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install -i https://test.pypi.org/simple hip-python)
+    # add python-hip for perf tests (moved to rocPyDecode-requirements.py)
+    #execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade pip)
+    #execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install -i https://test.pypi.org/simple hip-python)
 
     #run tests
     add_test(NAME video_decode_python_H265


### PR DESCRIPTION
Moving 2 lines from CMakeLists.txt to rocPyDecode-requirements.py to avoid build errors that says No module named pip.
To test successfully you shouldn't see the 2 messages saying [/usr/bin/python3.10: No module named pip] during the build time.