### PR TITLE
Changing the order of the arguments making most optional

### DIFF
--- a/pyRocVideoDecode/decoder.py
+++ b/pyRocVideoDecode/decoder.py
@@ -58,14 +58,14 @@ def GetRocPyDecPacket(pts, size, buffer):
 class decoder(object):
     def __init__(
             self,
-            device_id,
-            mem_type,
             codec,
-            b_force_zero_latency,
-            crop_rect,
-            max_width,
-            max_height,
-            clk_rate):
+            device_id = 0,
+            mem_type = 0,
+            b_force_zero_latency = False,
+            crop_rect = None,
+            max_width = 0,
+            max_height = 0,
+            clk_rate = 1000):
         p_crop_rect = GetRectangle(crop_rect)
         self.viddec = rocpydec.PyRocVideoDecoder(
             device_id,

--- a/samples/videodecode.py
+++ b/samples/videodecode.py
@@ -27,7 +27,15 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(codec_id, device_id)
+    viddec = dec.decoder(
+        codec_id,
+        device_id,
+        mem_type,
+        b_force_zero_latency,
+        crop_rect,
+        0,
+        0,
+        1000)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecode.py
+++ b/samples/videodecode.py
@@ -27,15 +27,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        device_id,
-        mem_type,
-        codec_id,
-        b_force_zero_latency,
-        crop_rect,
-        0,
-        0,
-        1000)
+    viddec = dec.decoder(codec_id, device_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodemem.py
+++ b/samples/videodecodemem.py
@@ -27,7 +27,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(codec_id, device_id)
+    viddec = dec.decoder(codec_id, device_id, mem_type)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodemem.py
+++ b/samples/videodecodemem.py
@@ -27,15 +27,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        device_id,
-        mem_type,
-        codec_id,
-        b_force_zero_latency,
-        crop_rect,
-        0,
-        0,
-        1000)
+    viddec = dec.decoder(codec_id, device_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodeperf.py
+++ b/samples/videodecodeperf.py
@@ -26,9 +26,9 @@ def DecProc(input_file_path, device_id, p_frames, p_fps):
 
     # decoder instance
     viddec = dec.decoder(
+        codec = codec_id,
         device_id = device_id,
         mem_type = 1,
-        codec = codec_id,
         b_force_zero_latency = False,
         crop_rect = None,
         max_width = 0,

--- a/samples/videodecodeperf.py
+++ b/samples/videodecodeperf.py
@@ -25,15 +25,7 @@ def DecProc(input_file_path, device_id, p_frames, p_fps):
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        codec = codec_id,
-        device_id = device_id,
-        mem_type = 1,
-        b_force_zero_latency = False,
-        crop_rect = None,
-        max_width = 0,
-        max_height = 0,
-        clk_rate = 1000)
+    viddec = dec.decoder(codec_id, device_id, mem_type = 3)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodergb.py
+++ b/samples/videodecodergb.py
@@ -22,15 +22,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        device_id,
-        mem_type,
-        codec_id,
-        b_force_zero_latency,
-        crop_rect,
-        0,
-        0,
-        1000)
+    viddec = dec.decoder(codec_id, device_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodergb.py
+++ b/samples/videodecodergb.py
@@ -22,7 +22,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(codec_id, device_id)
+    viddec = dec.decoder(codec_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodetorch.py
+++ b/samples/videodecodetorch.py
@@ -22,15 +22,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        device_id,
-        mem_type,
-        codec_id,
-        b_force_zero_latency,
-        crop_rect,
-        0,
-        0,
-        1000)
+    viddec = dec.decoder(codec_id, device_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodetorch.py
+++ b/samples/videodecodetorch.py
@@ -22,7 +22,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(codec_id, device_id)
+    viddec = dec.decoder(codec_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodetorch_resnet50.py
+++ b/samples/videodecodetorch_resnet50.py
@@ -37,15 +37,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(
-        device_id,
-        1,
-        codec_id,
-        False,
-        None,
-        0,
-        0,
-        1000)
+    viddec = dec.decoder(codec_id, device_id, 1)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()

--- a/samples/videodecodetorch_resnet50.py
+++ b/samples/videodecodetorch_resnet50.py
@@ -37,7 +37,7 @@ def Decoder(
     codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
 
     # decoder instance
-    viddec = dec.decoder(codec_id, device_id, 1)
+    viddec = dec.decoder(codec_id)
 
     # Get GPU device information
     cfg = viddec.GetGpuInfo()


### PR DESCRIPTION
Minimizing the count of 'needed' args to construct rocPyDecode, only codec_id needed, all other args are optional with default values.