### PR TITLE
Adding mem_type to perf example, README file, Samples tested

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -11,13 +11,13 @@ The torch python sample requires pytorch for ROCm, which can be installed as fol
 
 - If using bare-metal, `sudo` access is needed.
 ```bash
-    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
     sudo reboot 
 ```
 
 - If using a docker environment or any system with `root` access, no need for reboot.
 ```bash
-    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
 ```
 
 The performance sample requires python HIP, which can be installed as follows:
@@ -39,7 +39,7 @@ The following are full list of arguments that can be passed to the sample.
 -i INPUT, --input INPUT                          : Input File Path - required
 -o OUTPUT, --output OUTPUT                       : Output File Path - optional
 -d DEVICE, --device DEVICE                       : GPU device ID - optional, default - 0
--m MEM_TYPE, --mem_type MEM_TYPE                 : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied - optional, default 1
+-m MEM_TYPE, --mem_type MEM_TYPE                 : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 0
 -z ZERO_LATENCY, --zero_latency ZERO_LATENCY     : Force zero latency - [options: yes,no], default: no
 -crop CROP_RECT, --crop_rect CROP_RECT           : Crop rectangle (left, top, right, bottom) - optional, default: None (no cropping)
 -s SEEK, --seek SEEK                             : seek this number of frames, optional, default: no seek
@@ -63,6 +63,7 @@ The following are full list of arguments that can be passed to the sample.
 -h, --help                                                  : Show detail help message and exit
 -i INPUT, --input INPUT                                     : Input File Path - required
 -d DEVICE, --device DEVICE                                  : GPU device ID - optional, default - 0
+-m MEM_TYPE, --mem_type MEM_TYPE                            : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 3
 -t Number of Processes, --num_process Number of Processes   : Number of Processes - optional, default 4
 ```
 
@@ -77,7 +78,7 @@ The following are full list of arguments that can be passed to the sample.
 -i INPUT, --input INPUT                       : Input File Path - required
 -o OUTPUT, --output OUTPUT                    : Output File Path - optional
 -d DEVICE, --device DEVICE                    : GPU device ID - optional, default - 0
--m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied - optional, default 1
+-m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 0
 -z ZERO_LATENCY, --zero_latency ZERO_LATENCY  : Force zero latency - [options: yes,no], default: no
 -crop CROP_RECT, --crop_rect CROP_RECT        : Crop rectangle (left, top, right, bottom) - optional, default: None (no cropping)
 -of RGB_FORMAT, --rgb_format RGB_FORMAT       : Rgb Format to use - 1:bgr, 3:rgb, converts decoded YUV frame to Tensor in RGB format, optional, default: 3
@@ -94,7 +95,7 @@ The following are full list of arguments that can be passed to the sample.
 -i INPUT, --input INPUT                       : Input File Path - required
 -o OUTPUT, --output OUTPUT                    : Output File Path - optional
 -d DEVICE, --device DEVICE                    : GPU device ID - optional, default - 0
--m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied - optional, default 1
+-m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 0
 -z ZERO_LATENCY, --zero_latency ZERO_LATENCY  : Force zero latency - [options: yes,no], default: no
 -crop CROP_RECT, --crop_rect CROP_RECT        : Crop rectangle (left, top, right, bottom) - optional, default: None (no cropping)
 -of RGB_FORMAT, --rgb_format RGB_FORMAT       : Rgb Format to use - 1:bgr, 3:rgb, converts decoded YUV frame to Tensor in RGB format, optional, default: 3
@@ -112,7 +113,7 @@ The following are full list of arguments that can be passed to the sample.
 -i INPUT, --input INPUT                       : Input File Path - required
 -o OUTPUT, --output OUTPUT                    : Output File Path - optional
 -d DEVICE, --device DEVICE                    : GPU device ID - optional, default - 0
--m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied - optional, default 1
+-m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 0
 -z ZERO_LATENCY, --zero_latency ZERO_LATENCY  : Force zero latency - [options: yes,no], default: no
 -crop CROP_RECT, --crop_rect CROP_RECT        : Crop rectangle (left, top, right, bottom) - optional, default: None (no cropping)
 ```
@@ -129,7 +130,7 @@ The following are full list of arguments that can be passed to the sample.
 -i INPUT, --input INPUT                       : Input File Path - required
 -o OUTPUT, --output OUTPUT                    : Output File Path - optional
 -d DEVICE, --device DEVICE                    : GPU device ID - optional, default - 0
--m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied - optional, default 1
+-m MEM_TYPE, --mem_type MEM_TYPE              : Memory Type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped - optional, default 0
 -z ZERO_LATENCY, --zero_latency ZERO_LATENCY  : Force zero latency - [options: yes,no], default: no
 -crop CROP_RECT, --crop_rect CROP_RECT        : Crop rectangle (left, top, right, bottom) - optional, default: None (no cropping)
 ```

--- a/samples/videodecode.py
+++ b/samples/videodecode.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
         '--mem_type',
         type=int,
         default=1,
-        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied optional, default 1',
+        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 0',
         required=False)
     parser.add_argument(
         '-z',

--- a/samples/videodecodemem.py
+++ b/samples/videodecodemem.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
         '--mem_type',
         type=int,
         default=1,
-        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied optional, default 1',
+        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 0',
         required=False)
     parser.add_argument(
         '-z',

--- a/samples/videodecodeperf.py
+++ b/samples/videodecodeperf.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
         '-m',
         '--mem_type',
         type=int,
-        default=1,
+        default=3,
         help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 3',
         required=False)
     try:

--- a/samples/videodecodergb.py
+++ b/samples/videodecodergb.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         '--mem_type',
         type=int,
         default=1,
-        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied optional, default 1',
+        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 0',
         required=False)
     parser.add_argument(
         '-z',
@@ -183,7 +183,6 @@ if __name__ == "__main__":
         print("ERROR: input file doesn't exist.")
         exit()
 
-    print("rgb_format: ", rgb_format)
     Decoder(
         input_file_path,
         output_file_path,

--- a/samples/videodecodetorch.py
+++ b/samples/videodecodetorch.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
         '--mem_type',
         type=int,
         default=1,
-        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied optional, default 1',
+        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 0',
         required=False)
     parser.add_argument(
         '-z',

--- a/samples/videodecodetorch_yuv.py
+++ b/samples/videodecodetorch_yuv.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
         '--mem_type',
         type=int,
         default=1,
-        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied optional, default 1',
+        help='mem_type of output surfce - 0: Internal 1: dev_copied 2: host_copied 3: MEM not mapped, optional, default 0',
         required=False)
     parser.add_argument(
         '-z',


### PR DESCRIPTION
Adding mem_type to perf example, modifying README file to reflecton all, adjusted default mem type to 0 in all except perf to 3, tested all samples successfully