### PR TITLE
Create rocPyDecode Python distribution wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ if(HIP_FOUND AND rocDecode_FOUND AND pybind11_FOUND AND Python3_FOUND AND FFMPEG
     message("-- ${BoldBlue}rocPyDecode Version -- ${VERSION}${ColourReset}")
     message("-- ${BoldBlue}rocPyDecode Install Path -- ${CMAKE_INSTALL_PREFIX_PYTHON}${ColourReset}")
 
+    # export needed path as variables
+    file(WRITE ./export_path "${ROCM_PATH}/include/rocdecode/\n" "${ROCM_PATH}/share/rocdecode/utils/\n" "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/\n" "${HIP_INCLUDE_DIRS}\n" "${pybind11_INCLUDE_DIRS}\n" "${ROCM_PATH}\n")
+
     # make test with CTest
     enable_testing()
     include(CTest)

--- a/build_rocpydecode_wheel.py
+++ b/build_rocpydecode_wheel.py
@@ -1,0 +1,18 @@
+import subprocess
+import os
+import shutil
+
+# Clean any existing build/dist files
+if os.path.exists('build'):
+    shutil.rmtree('build')
+if os.path.exists('dist'):
+    shutil.rmtree('dist')
+
+# Build the source distribution and wheel
+subprocess.run(['python3', 'setup.py', 'sdist', 'bdist_wheel', 'install'], check=True)
+
+# Verify the content of the created wheel
+wheel_dir = os.path.join('dist')
+wheel_files = os.listdir(wheel_dir)
+
+print(f"Wheel files created: {wheel_files}")

--- a/build_rocpydecode_wheel.py
+++ b/build_rocpydecode_wheel.py
@@ -9,7 +9,7 @@ if os.path.exists('dist'):
     shutil.rmtree('dist')
 
 # Build the source distribution and wheel
-subprocess.run(['python3', 'setup.py', 'sdist', 'bdist_wheel', 'install'], check=True)
+subprocess.run(['python3', 'setup.py', 'bdist_wheel', 'sdist', 'install'], check=True)
 
 # Verify the content of the created wheel
 wheel_dir = os.path.join('dist')

--- a/setup.py
+++ b/setup.py
@@ -89,11 +89,11 @@ def get_relative_path(target_path, current_folder):
 
 # pickup cmake path location(s)
 with open('export_path', 'r') as file:
-    rocDecode_Headers = file.readline().strip() # rocDecode H
+    rocdecode_headers = file.readline().strip() # rocDecode H
     utils_folder = file.readline().strip() # UTIL
     decoder_class_folder = file.readline().strip() # Video Decode
-    HIP_Headers = file.readline().strip() # HIP
-    pybind11_Headers = file.readline().strip() #  pybind11
+    hip_headers = file.readline().strip() # HIP
+    pybind11_headers = file.readline().strip() #  pybind11
     rocm_path = file.readline().strip() #  ROCM_PATH
 # bring in reltaive path
 current_folder = str(os.system('pwd'))
@@ -106,7 +106,7 @@ os.environ["CXX"] = rocm_path+'/bin/hipcc'
 # Define the extension module
 ext_modules = [Extension('rocPyDecode',
     sources=['src/roc_pydecode.cpp','src/roc_pybuffer.cpp','src/roc_pydlpack.cpp','src/roc_pyvideodecode.cpp','src/roc_pyvideodemuxer.cpp',src_utils+'/colorspace_kernels.cpp', src_utils+'/resize_kernels.cpp', vdu_utils+'/roc_video_dec.cpp'],
-    include_dirs=[rocDecode_Headers,utils_folder,decoder_class_folder,HIP_Headers,pybind11_Headers],
+    include_dirs=[rocdecode_headers,utils_folder,decoder_class_folder,hip_headers,pybind11_headers],
     extra_compile_args=['-D__HIP_PLATFORM_AMD__','-Wno-sign-compare','-Wno-reorder','-Wno-int-in-bool-context', '-Wno-unused-variable','-Wno-missing-braces','-Wno-unused-private-field','-Wno-unused-function'],
     distclass=BinaryDistribution,
     library_dirs=[rocm_path+'/lib/'],
@@ -120,8 +120,8 @@ setup(
     author='AMD',
     license='MIT License',
     include_package_data=True,
-    packages=['pyRocVideoDecode', 'samples'],
-    package_dir={'pyRocVideoDecode':'pyRocVideoDecode', 'samples':'samples'},
+    packages=['pyRocVideoDecode', 'pyRocVideoDecode/samples'],
+    package_dir={'pyRocVideoDecode':'pyRocVideoDecode', 'pyRocVideoDecode/samples':'samples'},
     package_data={"pyRocVideoDecode":["__init__.pyi"], 'rocPyDecode': ['*.so']},  # Include .so files in the package
     cmdclass={'bdist_wheel': custom_bdist_wheel,},
     ext_modules=ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,15 @@ vdu_utils = get_relative_path(decoder_class_folder, current_folder)
 os.environ["CC"] = rocm_path+'/bin/hipcc'
 os.environ["CXX"] = rocm_path+'/bin/hipcc'
 
+# Define the extension module
+ext_modules = [Extension('rocPyDecode',
+    sources=['src/roc_pydecode.cpp','src/roc_pybuffer.cpp','src/roc_pydlpack.cpp','src/roc_pyvideodecode.cpp','src/roc_pyvideodemuxer.cpp',src_utils+'/colorspace_kernels.cpp', src_utils+'/resize_kernels.cpp', vdu_utils+'/roc_video_dec.cpp'],
+    include_dirs=[rocDecode_Headers,utils_folder,decoder_class_folder,HIP_Headers,pybind11_Headers],
+    extra_compile_args=['-D__HIP_PLATFORM_AMD__','-Wno-sign-compare','-Wno-reorder','-Wno-int-in-bool-context', '-Wno-unused-variable','-Wno-missing-braces','-Wno-unused-private-field','-Wno-unused-function'],
+    distclass=BinaryDistribution,
+    library_dirs=[rocm_path+'/lib/'],
+    libraries=['rocdecode','avcodec','avformat','avutil'])]
+
 setup(
     name='rocPyDecode',
     description='AMD ROCm Video Decoder Library',
@@ -115,14 +124,7 @@ setup(
     package_dir={'pyRocVideoDecode':'pyRocVideoDecode', 'samples':'samples'},
     package_data={"pyRocVideoDecode":["__init__.pyi"], 'rocPyDecode': ['*.so']},  # Include .so files in the package
     cmdclass={'bdist_wheel': custom_bdist_wheel,},
-    ext_modules=
-    [Extension('rocPyDecode',
-    sources=['src/roc_pydecode.cpp','src/roc_pybuffer.cpp','src/roc_pydlpack.cpp','src/roc_pyvideodecode.cpp','src/roc_pyvideodemuxer.cpp',src_utils+'/colorspace_kernels.cpp', src_utils+'/resize_kernels.cpp', vdu_utils+'/roc_video_dec.cpp'],
-    include_dirs=[rocDecode_Headers,utils_folder,decoder_class_folder,HIP_Headers,pybind11_Headers],
-    extra_compile_args=['-D__HIP_PLATFORM_AMD__','-Wno-sign-compare','-Wno-reorder','-Wno-int-in-bool-context', '-Wno-unused-variable','-Wno-missing-braces','-Wno-unused-private-field','-Wno-unused-function'],
-    distclass=BinaryDistribution,
-    library_dirs=[rocm_path+'/lib/','/usr/local/lib/','/usr/lib/x86_64-linux-gnu/'],
-    libraries=['rocdecode','avcodec','avformat','avutil'])],
+    ext_modules=ext_modules,
     )
 
 # Test built binaries -- TBD: Optional

--- a/setup.py
+++ b/setup.py
@@ -76,17 +76,18 @@ subprocess.check_call(['cmake', '--build', build_dir, '--config', 'Release', '--
 subprocess.check_call(['cmake', '--install', build_dir])
 
 setup(
-      name='rocPyDecode',
-      description='AMD ROCm Video Decoder Library',
-      url='https://github.com/ROCm/rocPyDecode',
-      version='1.0.0' + '.' + get_rocm_rev(),
-      author='AMD',
-      license='MIT License',
-      packages=['pyRocVideoDecode'],
-      package_dir={'pyRocVideoDecode':'pyRocVideoDecode'},
-      package_data={"pyRocVideoDecode":["__init__.pyi"]},
-      cmdclass={'bdist_wheel': custom_bdist_wheel,},
-      )
+    name='rocPyDecode',
+    description='AMD ROCm Video Decoder Library',
+    url='https://github.com/ROCm/rocPyDecode',
+    version='1.0.0' + '.' + get_rocm_rev(),
+    author='AMD',
+    license='MIT License',
+    include_package_data=True,
+    packages=['pyRocVideoDecode', 'samples'],
+    package_dir={'pyRocVideoDecode':'pyRocVideoDecode', 'pyRocVideoDecode/samples':'samples'},
+    package_data={"pyRocVideoDecode":["__init__.pyi"]},
+    cmdclass={'bdist_wheel': custom_bdist_wheel,},
+    )
 
 # Test built binaries -- TBD: Optional
 # subprocess.check_call(['ctest', '--test-dir', build_dir, '-VV'])

--- a/src/roc_pybuffer.cpp
+++ b/src/roc_pybuffer.cpp
@@ -64,6 +64,7 @@ std::string BufferInterface::dtype() const {
         return std::string("|u1");
     else if (m_dlTensor->dtype.bits == 16)
         return std::string("|u2");
+    return std::string("|u1"); // non-void function must ret value
 }
 
 void *BufferInterface::data() const {


### PR DESCRIPTION
**

> **Create a distribution wheel for rocPyDecode**

**

In order to create a distribution wheel for rocPyDecode, you must use the added script 'build_rocpydecode_wheel.py', as follow:

**-- on the rocPyDecode folder --:**
sudo python3 **build_rocpydecode_wheel.py**

**-- if previous attempt made, it is recommended to cleanup before running the script above, as follow:**
	sudo rm -rf build/
	sudo rm -rf dist/
	sudo rm -rf rocPyDecode.egg-info/
	sudo pip3 uninstall rocPyDecode -y
	#-- or if not used pip3 then: --
	pip3 uninstall rocPyDecode -y 
	# then create the wheel
	sudo python3 build_rocpydecode_wheel.py

**if the objective is NOT just to create the wheel but also to install it, add the following command:**
-- create the wheel
	sudo python3 build_rocpydecode_wheel.py
-- install it (assuming you are still on rocPyDecode folder)
	sudo pip3 install ./dist/rocPyDecode-1.0.0.60300-~_2_28_x86_64.**whl**
-- on any other folder just use the full path of where the wheel is:
	sudo pip3 install /full-path-wheel-location/rocPyDecode-1.0.0.60300-~2_28_x86_64.**whl**

**-- The original method of building/installing the rocPyDecode still can be used** INSTEAD, but it is NOT needed if you create and install the wheel.
	sudo pip3 install . -v # not needed if already created and installed the wheel

**-- You can create the wheel and not install it, send it to the customer with instruction how to install it.**

**-- You can create the wheel and still install rocPyDecode using the original method:**
	sudo pip3 install . -v 

**-- After installing via the WHEEL or via pip3 install . you can locate the .so file as follow:**
	sudo find / -name "rocPyDecode*.so"		# just to see it is there, this step is not needed for customers

**-- The wheel includes now the "python samples", you can also locate them via:**	
	sudo find / -name "videodecode*.py"

**-- The wheel content can be viewed as follow (assuming you are on the rocPyDecode folder):**
	**unzip** -l dist/rocPyDecode-1.0.0.60300-~_2_28_x86_64.**whl**

**-- The content look like this:**

essam_aly@CV1:~/rocPyDecode$ **unzip -l dist/wheel_file_name.whl**

Archive:  dist/rocPyDecode-1.0.0.60300-~_2_28_x86_64.**whl**

Length 	Date 		Time 	Name

8112888 2024-09-27	22:57	rocPyDecode.cpython-310-x86_64-linux-gnu.so <<-- the .so file
1135 	2024-09-27	05:35	pyRocVideoDecode/init.py
1798 	2024-09-27	05:35	pyRocVideoDecode/init.pyi
5744 	2024-09-27	05:35	pyRocVideoDecode/decoder.py
2020 	2024-09-27	05:35	pyRocVideoDecode/demuxer.py
3726 	2024-09-27	05:35	pyRocVideoDecode/types.py
9637 	2024-09-27	05:35	samples/videodecode.py
7856 	2024-09-27	05:35	samples/videodecodemem.py
5628 	2024-09-27	05:35	samples/videodecodeperf.py
5635 	2024-09-27	05:35	samples/videodecodergb.py
5461 	2024-09-27	05:35	samples/videodecodetorch.py
5772 	2024-09-27	05:35	samples/videodecodetorch_resnet50.py
6414 	2024-09-27	05:35	samples/videodecodetorch_yuv.py
1077 	2024-09-27	22:57	rocPyDecode-1.0.0.60300.dist-info/LICENSE
231 	        2024-09-27	22:57	rocPyDecode-1.0.0.60300.dist-info/METADATA
114 	       2024-09-27	22:57	rocPyDecode-1.0.0.60300.dist-info/WHEEL
37 		2024-09-27	22:57	rocPyDecode-1.0.0.60300.dist-info/top_level.txt
1551 	2024-09-27	22:57	rocPyDecode-1.0.0.60300.dist-info/RECORD

8176724 
18 files

**_The creation of the wheel in this method is automated, just run the script, it will build rocPyDecode and creates its wheel without installing it. Installing it is an extra step, which is typically done as intended by the user/customer. The daily builds can use this method to create daily wheel for rocPyDecode._**