### PR TITLE
rocPyDecode version everywhere is 0.2.0 now, to avoid version mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocPyDecode is available at
 [https://rocm.docs.amd.com/projects/rocPyDecode/en/latest/](https://rocm.docs.amd.com/projects/rocPyDecode/en/latest/)
 
-## rocPyDecode 0.1.0 (Unreleased)
+## rocPyDecode 0.2.0 (Unreleased)
 
 ## Additions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set(VERSION "0.1.0")
+set(VERSION "0.2.0")
 set(CMAKE_CXX_STANDARD 17)
 
 # Set Project Version and Language

--- a/rocPyDecode-requirements.py
+++ b/rocPyDecode-requirements.py
@@ -29,8 +29,7 @@ else:
     import subprocess
 
 __copyright__ = "Copyright (c) 2024, AMD ROCm rocPyDecode"
-__version__ = "1.0.0"
-__email__ = "mivisionx.support@amd.com"
+__version__ = "0.2.0"
 __status__ = "Shipping"
 
 # error check calls

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
     name='rocPyDecode',
     description='AMD ROCm Video Decoder Library',
     url='https://github.com/ROCm/rocPyDecode',
-    version='1.0.0' + '.' + get_rocm_rev(),
+    version='0.2.0' + '.' + get_rocm_rev(),
     author='AMD',
     license='MIT License',
     include_package_data=True,


### PR DESCRIPTION
Setting all version # reference to 0.2.0 for rocPyDecode to avoid any mismatch.