### PR TITLE
Not using CodecSupported() API from rocDecode if ROCM version less than 6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,13 @@ if(HIP_FOUND AND rocDecode_FOUND AND pybind11_FOUND AND Python3_FOUND AND FFMPEG
         target_compile_definitions(${TARGET_NAME} PUBLIC OVERHEAD_SUPPORT=0)
     endif()
 
+    # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
+    if(${ROCDECODE_MAJOR_VERSION} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_MINOR_VERSION} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_MICRO_VERSION} VERSION_GREATER_EQUAL "0")
+        target_compile_definitions(${TARGET_NAME} PUBLIC CODEC_SUPPORTED_CHECK=1)
+    else()
+        target_compile_definitions(${TARGET_NAME} PUBLIC CODEC_SUPPORTED_CHECK=0)
+    endif()
+
     set_target_properties(${TARGET_NAME} PROPERTIES
         PREFIX "${PYTHON_MODULE_PREFIX}"
         SUFFIX "${PYTHON_MODULE_EXTENSION}"

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -421,10 +421,10 @@ py::int_ PyRocVideoDecoder::PyGetStride() {
 
 // for python binding
 py::object PyRocVideoDecoder::PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth) {
-#if defined(HIP_VERSION_MINOR) && HIP_VERSION_MINOR < 3
-    bool ret = true; // TODO: remove the whole #if directive when ROCM 6.3 is public, only keep CodecSupported()
-#else
+#if CODEC_SUPPORTED_CHECK
     bool ret = CodecSupported(device_id, codec_id, bit_depth);
+#else
+    bool ret = true; // TODO: remove the whole #if CODEC_SUPPORTED_CHECK directive when ROCM 6.3 is public, only keep CodecSupported()
 #endif
     return py::cast(ret);
 }

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -421,7 +421,11 @@ py::int_ PyRocVideoDecoder::PyGetStride() {
 
 // for python binding
 py::object PyRocVideoDecoder::PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth) {
+#if defined(HIP_VERSION_MINOR) && HIP_VERSION_MINOR < 3
+    bool ret = true; // TODO: remove the whole #if directive when ROCM 6.3 is public, only keep CodecSupported()
+#else
     bool ret = CodecSupported(device_id, codec_id, bit_depth);
+#endif
     return py::cast(ret);
 }
 


### PR DESCRIPTION
Avoid any build issues when build against ROCm 6.2.2 or less, when build with 6.3 or higher no issues.