### PR TITLE
Fixing CI build issues and install the wheel when building

### DIFF
--- a/build_rocpydecode_wheel.py
+++ b/build_rocpydecode_wheel.py
@@ -9,10 +9,10 @@ if os.path.exists('dist'):
     shutil.rmtree('dist')
 
 # Build the source distribution and wheel
-subprocess.run(['python3', 'setup.py', 'bdist_wheel', 'sdist', 'install'], check=True)
+subprocess.run(['sudo', 'python3', 'setup.py', 'bdist_wheel'], check=True) # build wheel & install it
 
 # Verify the content of the created wheel
 wheel_dir = os.path.join('dist')
 wheel_files = os.listdir(wheel_dir)
 
-print(f"Wheel files created: {wheel_files}")
+print(f"rocPyDecode wheel files created: {wheel_files}\n")


### PR DESCRIPTION
Fixing CI build issues and install the wheel when building it with the same command one scrip does all:

**python3 build_rocpydecode_wheel.py** # no need to sudo here

This script builds and installs the wheel.
The wheel will be saved under sub folder ./dist/

Alternative method to using the script is the following command:
-- while on the same folder of rocPyDecode
**sudo python3 setup.py bdist_wheel   # build & install**