### PR TITLE
Fix External CI wheel creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(HIP_FOUND AND rocDecode_FOUND AND pybind11_FOUND AND Python3_FOUND AND FFMPEG
         PREFIX "${PYTHON_MODULE_PREFIX}"
         SUFFIX "${PYTHON_MODULE_EXTENSION}"
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}")
-    set(TARGET_PYMODULE_NAME "${PYTHON_MODULE_PREFIX}${TARGET_NAME}${PYTHON_MODULE_EXTENSION}")                                              
+    set(TARGET_PYMODULE_NAME "${PYTHON_MODULE_PREFIX}${TARGET_NAME}${PYTHON_MODULE_EXTENSION}")
 
     foreach (filename ${pyfiles})
         get_filename_component(target "${filename}" REALPATH)
@@ -170,7 +170,7 @@ if(HIP_FOUND AND rocDecode_FOUND AND pybind11_FOUND AND Python3_FOUND AND FFMPEG
     message("-- ${BoldBlue}rocPyDecode Install Path -- ${CMAKE_INSTALL_PREFIX_PYTHON}${ColourReset}")
 
     # export needed path as variables
-    file(WRITE ./export_path "${ROCM_PATH}/include/rocdecode/\n" "${ROCM_PATH}/share/rocdecode/utils/\n" "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/\n" "${HIP_INCLUDE_DIRS}\n" "${pybind11_INCLUDE_DIRS}\n" "${ROCM_PATH}\n")
+    file(WRITE ./export_path "${ROCM_PATH}/include/rocdecode/\n" "${ROCM_PATH}/share/rocdecode/utils/\n" "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/\n" "${HIP_INCLUDE_DIRS}\n" "${ROCM_PATH}\n")
 
     # make test with CTest
     enable_testing()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@
 
 import subprocess
 import os
+import pybind11
 from setuptools import setup, find_packages, Extension
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from setuptools.dist import Distribution
@@ -77,10 +78,10 @@ cmake_args=["cmake", ".", "-B"+build_dir, "-H"+os.getcwd()]
 subprocess.check_call(cmake_args,cwd=os.getcwd())
 
 # Invoke cmake --build to build the project
-subprocess.check_call(['cmake', '--build', build_dir, '--config', 'Release', '--parallel'])
+subprocess.check_call(['cmake', '--build', build_dir, '--config', 'Release', '--parallel'],cwd=os.getcwd())
 
 # Install the built binaries
-subprocess.check_call(['cmake', '--install', build_dir])
+subprocess.check_call(['cmake', '--install', build_dir],cwd=os.getcwd())
 
 # Calculate Relative Path, to avoid error: arguments must *always* be /-separated paths relative to the setup.py directory
 def get_relative_path(target_path, current_folder):
@@ -93,10 +94,10 @@ with open('export_path', 'r') as file:
     utils_folder = file.readline().strip() # UTIL
     decoder_class_folder = file.readline().strip() # Video Decode
     hip_headers = file.readline().strip() # HIP
-    pybind11_headers = file.readline().strip() #  pybind11
     rocm_path = file.readline().strip() #  ROCM_PATH
-# bring in reltaive path
-current_folder = str(os.system('pwd'))
+pybind11_headers = pybind11.get_include() #  pybind11
+# bring in relative path
+current_folder = str(os.getcwd())
 src_utils = get_relative_path(utils_folder, current_folder)
 vdu_utils = get_relative_path(decoder_class_folder, current_folder)
 # use compiler recognize the kernel code


### PR DESCRIPTION
- Make working directory consistent across all subprocess calls and path determinations.
- Use python functionality to determine pybind11's include directory.
- [Pipeline build log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=9371&view=results) where wheel creation works. Testing was cancelled to save resources. 