### PR TITLE
Clean up setup.py for building and installing the wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,6 @@ if(HIP_FOUND AND rocDecode_FOUND AND pybind11_FOUND AND Python3_FOUND AND FFMPEG
     message("-- ${BoldBlue}rocPyDecode Version -- ${VERSION}${ColourReset}")
     message("-- ${BoldBlue}rocPyDecode Install Path -- ${CMAKE_INSTALL_PREFIX_PYTHON}${ColourReset}")
 
-    # export needed path as variables
-    file(WRITE ./export_path "${ROCM_PATH}/include/rocdecode/\n" "${ROCM_PATH}/share/rocdecode/utils/\n" "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/\n" "${HIP_INCLUDE_DIRS}\n" "${ROCM_PATH}\n")
-
     # make test with CTest
     enable_testing()
     include(CTest)


### PR DESCRIPTION
Inserting the .so library inside the generated Python Wheel while building only once, without hipcc, and without need to use text file to export path from cmake to setup. Reduced code lines, in a faster process.