### PR TITLE
Samples using rocDecode package videos instead of rocPyDecode

### DIFF
--- a/rocPyDecode-docker-install.py
+++ b/rocPyDecode-docker-install.py
@@ -84,4 +84,4 @@ else:
     os.system('python3 setup.py install')
 
 # how to test
-print("\nTo test rocPyDecode run the following command:\n","python3 samples/videodecode.py -i data/videos/AMD_driving_virtual_20-H265.mp4","\n")
+print("\nTo test rocPyDecode run the following command:\n","python3 samples/videodecode.py -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4","\n")

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -34,29 +34,29 @@ if(Python3_FOUND)
     #run tests
     add_test(NAME video_decode_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-H265.mp4 
+            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-H265.mp4 
+            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_rgb_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodergb.py
-            -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-H265.mp4 
+            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
             -of 3
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-H264.mp4 
+            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-H264.mp4 
+            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     if(${ROCDECODE_MAJOR_VERSION} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_MINOR_VERSION} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_MICRO_VERSION} VERSION_GREATER_EQUAL "0")
         add_test(NAME video_decode_python_AV1
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-        -i ${CMAKE_SOURCE_DIR}/data/videos/AMD_driving_virtual_20-AV1.mp4 
+        -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4 
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}) 
     endif() 
 endif(Python3_FOUND)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -25,6 +25,15 @@ cmake_minimum_required(VERSION 3.5)
 set(Python3_FIND_VIRTUALENV FIRST)
 find_package(Python3 QUIET)
 
+# ROCM Path
+if(DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
+elseif(ROCM_PATH)
+  message("-- ${White}${PROJECT_NAME} :ROCM_PATH Set -- ${ROCM_PATH}${ColourReset}")
+else()
+  set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
+endif()
+
 # rocPyDecode tests
 if(Python3_FOUND)
     # add python-hip for perf tests
@@ -34,29 +43,29 @@ if(Python3_FOUND)
     #run tests
     add_test(NAME video_decode_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
+            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
+            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_rgb_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodergb.py
-            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 
+            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             -of 3
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 
+            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 
+            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     if(${ROCDECODE_MAJOR_VERSION} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_MINOR_VERSION} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_MICRO_VERSION} VERSION_GREATER_EQUAL "0")
         add_test(NAME video_decode_python_AV1
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-        -i /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4 
+        -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}) 
     endif() 
 endif(Python3_FOUND)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -43,29 +43,29 @@ if(Python3_FOUND)
     #run tests
     add_test(NAME video_decode_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_rgb_python_H265
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodergb.py
-            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             -of 3
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_test(NAME video_decode_perf_python_H264
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecodeperf.py
-            -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     if(${ROCDECODE_MAJOR_VERSION} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_MINOR_VERSION} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_MICRO_VERSION} VERSION_GREATER_EQUAL "0")
         add_test(NAME video_decode_python_AV1
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/samples/videodecode.py
-        -i /${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
+        -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}) 
     endif() 
 endif(Python3_FOUND)


### PR DESCRIPTION
To avoid adding the video sub folder into the wheel, using the rocDecode package videos instead, changes made in files to reflect that. 