### PR TITLE
For CI, change dir to project build prefix before building rocDecode

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -63,7 +63,7 @@ def runTestCommand (platform, project) {
     def command = """#!/usr/bin/env bash
                 set -ex
                 export HOME=/home/jenkins
-                export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/:/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+                export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/:/usr/local/lib/x86_64-linux-gnu:\$LD_LIBRARY_PATH
                 echo make samples
                 sudo pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
                 cd ${project.paths.project_build_prefix}

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -60,6 +60,7 @@ def runTestCommand (platform, project) {
     def command = """#!/usr/bin/env bash
                 set -ex
                 export HOME=/home/jenkins
+                export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/:/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
                 echo make samples
                 sudo pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
                 cd ${project.paths.project_build_prefix}

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -9,7 +9,9 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     
     def command = """#!/usr/bin/env bash
                 set -ex
-
+                
+                cd ${project.paths.project_build_prefix}
+                
                 echo Build rocDecode
                 rm -rf rocDecode
                 git clone http://github.com/ROCm/rocDecode.git
@@ -23,7 +25,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 cd ../..
 
                 echo Build rocPyDecode - ${buildTypeDir}
-                cd ${project.paths.project_build_prefix}
                 
                 wget https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.tar.gz
                 tar -xvf v0.6.tar.gz

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -10,9 +10,10 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     def command = """#!/usr/bin/env bash
                 set -ex
                 
-                cd ${project.paths.project_build_prefix}/..
-                
                 echo Build rocDecode
+                pwd
+                cd ${project.paths.project_build_prefix}/..
+                pwd
                 rm -rf rocDecode
                 git clone http://github.com/ROCm/rocDecode.git
                 cd rocDecode
@@ -25,7 +26,9 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 cd ../..
 
                 echo Build rocPyDecode - ${buildTypeDir}
-                cd ${project.paths.project_build_prefix}
+                pwd
+                cd rocpydecode
+                pwd
                 wget https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.tar.gz
                 tar -xvf v0.6.tar.gz
                 cd dlpack-0.6

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -10,7 +10,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     def command = """#!/usr/bin/env bash
                 set -ex
                 
-                cd ${project.paths.project_build_prefix}
+                cd ${project.paths.project_build_prefix}/..
                 
                 echo Build rocDecode
                 rm -rf rocDecode
@@ -25,7 +25,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 cd ../..
 
                 echo Build rocPyDecode - ${buildTypeDir}
-                
+                cd ${project.paths.project_build_prefix}
                 wget https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.tar.gz
                 tar -xvf v0.6.tar.gz
                 cd dlpack-0.6

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -61,7 +61,7 @@ def runTestCommand (platform, project) {
                 set -ex
                 export HOME=/home/jenkins
                 echo make samples
-                sudo pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+                sudo pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
                 cd ${project.paths.project_build_prefix}
                 echo \$PYTHONPATH
                 LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/opt/rocm/lib${libLocation} sudo python3 samples/videodecode.py


### PR DESCRIPTION
to avoid having multiple CI runs on the same machine build rocDecode in the same directory

get torch from https://download.pytorch.org/whl/nightly/rocm6.2 due to error on sles run 
```
+ sudo pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.0
Looking in indexes: https://download.pytorch.org/whl/nightly/rocm6.0
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
```