### PR TITLE
take device id as input parameter for LoadDLPack function

### DIFF
--- a/src/roc_pybuffer.cpp
+++ b/src/roc_pybuffer.cpp
@@ -72,6 +72,7 @@ void *BufferInterface::data() const {
 }
 
 py::capsule BufferInterface::dlpack(py::object stream) const {
+    printf("I am in dlpack function\n");
     
     struct ManagerCtx {
         DLManagedTensor tensor;
@@ -135,11 +136,10 @@ void PyExportInitializer(py::module& m) {
     BufferInterface::Export(m);
 }
 
-int BufferInterface::LoadDLPack(std::vector<size_t>& _shape, std::vector<size_t>& _stride, uint32_t bit_depth, std::string& _type_str, void* _data) {
-    
+int BufferInterface::LoadDLPack(std::vector<size_t>& _shape, std::vector<size_t>& _stride, uint32_t bit_depth, std::string& _type_str, void* _data, int device_id_) {
     m_dlTensor->byte_offset = 0;
     m_dlTensor->device.device_type = kDLROCM;   // TODO: infer the device type from the memory buffer
-    m_dlTensor->device.device_id = 0;           // TODO: infer the device id   from the memory buffer
+    m_dlTensor->device.device_id = device_id_;
 
     // Convert data
     void* ptr = _data;

--- a/src/roc_pybuffer.cpp
+++ b/src/roc_pybuffer.cpp
@@ -72,7 +72,6 @@ void *BufferInterface::data() const {
 }
 
 py::capsule BufferInterface::dlpack(py::object stream) const {
-    printf("I am in dlpack function\n");
     
     struct ManagerCtx {
         DLManagedTensor tensor;

--- a/src/roc_pybuffer.h
+++ b/src/roc_pybuffer.h
@@ -46,7 +46,7 @@ class BufferInterface final : public std::enable_shared_from_this<BufferInterfac
 
         BufferInterface() = default;
         py::capsule dlpack(py::object stream) const;
-        int LoadDLPack(std::vector<size_t>& _shape, std::vector<size_t>& _stride, uint32_t bit_depth, std::string& _type_str, void* _data);
+        int LoadDLPack(std::vector<size_t>& _shape, std::vector<size_t>& _stride, uint32_t bit_depth, std::string& _type_str, void* _data, int device_id_);
 
     private:
         friend py::detail::type_caster<BufferInterface>;

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -181,7 +181,7 @@ py::object PyRocVideoDecoder::PyGetFrameYuv(PyPacketData& packet, bool SeparateY
         // The tensor shape->height will be all the Yuv planes if user specify 'FALSE' in 'SeparateYuvPlanes' argument
         float plane_height_multiplier = SeparateYuvPlanes ? 1.0 : 1.5; // 1.5 for YUV NV12
         std::vector<size_t> shape{ static_cast<size_t>(height * plane_height_multiplier), static_cast<size_t>(width)};
-        packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)packet.frame_adrs);
+        packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)packet.frame_adrs, device_id_);
         if (SeparateYuvPlanes) {
             // get surface format
             OutputSurfaceInfo* p_surf_info;
@@ -191,7 +191,7 @@ py::object PyRocVideoDecoder::PyGetFrameYuv(PyPacketData& packet, bool SeparateY
                 if (p_surf_info->surface_format == rocDecVideoSurfaceFormat_NV12 || p_surf_info->surface_format == rocDecVideoSurfaceFormat_P016) {
                     std::vector<size_t> shape{ static_cast<size_t>(height >> 1), static_cast<size_t>(width)};
                     uintptr_t uv_offset = p_surf_info->output_pitch * p_surf_info->output_vstride; // count for possible padding
-                    packet.ext_buf[1]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)(packet.frame_adrs + uv_offset));
+                    packet.ext_buf[1]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)(packet.frame_adrs + uv_offset), device_id_);
                 } else {
                     cout << "surf fmt: " << p_surf_info->surface_format << " [not supported]" << "\n";
                 }
@@ -257,7 +257,7 @@ py::object PyRocVideoDecoder::PyGetFrameRgb(PyPacketData& packet, int rgb_format
             std::string type_str(static_cast<const char*>("|u1"));
             std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width), 3}; // 3 rgb channels
             std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1, 0}; // python assumes same dim for both shape & strides
-            packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb);
+            packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb, device_id_);
         }
     }
     return py::cast(packet.frame_pts);

--- a/src/roc_pyvideodecode.h
+++ b/src/roc_pyvideodecode.h
@@ -46,8 +46,10 @@ class PyRocVideoDecoder : public RocVideoDecoder {
         PyRocVideoDecoder(int device_id, int mem_type, rocDecVideoCodec codec, bool force_zero_latency = false,
                           const Rect *p_crop_rect = nullptr, int max_width = 0, int max_height = 0,
                           uint32_t clk_rate = 0) : RocVideoDecoder(device_id, static_cast<OutputSurfaceMemoryType>(mem_type), codec, force_zero_latency,
-                          p_crop_rect, false, max_width, max_height, clk_rate) { InitConfigStructure(); }
-        ~PyRocVideoDecoder();                        
+                          p_crop_rect, false, max_width, max_height, clk_rate) { 
+                InitConfigStructure();
+                device_id_ = device_id; }
+        ~PyRocVideoDecoder();
          
         // for python binding
         int PyDecodeFrame(PyPacketData& packet);
@@ -105,6 +107,7 @@ class PyRocVideoDecoder : public RocVideoDecoder {
         py::object PyGetDecoderSessionOverHead(int session_id);
 #endif
     private:
+        int device_id_;
         size_t CalculateRgbImageSize(OutputFormatEnum& e_output_format, OutputSurfaceInfo* p_surf_info);
         std::shared_ptr <ConfigInfo> configInfo;
         void InitConfigStructure();

--- a/src/roc_pyvideodecodecpu.cpp
+++ b/src/roc_pyvideodecodecpu.cpp
@@ -181,7 +181,7 @@ py::object PyRocVideoDecoderCpu::PyGetFrameYuv(PyPacketData& packet, bool Separa
         // The tensor shape->height will be all the Yuv planes if user specify 'FALSE' in 'SeparateYuvPlanes' argument
         float plane_height_multiplier = SeparateYuvPlanes ? 1.0 : 1.5; // 1.5 for YUV NV12
         std::vector<size_t> shape{ static_cast<size_t>(height * plane_height_multiplier), static_cast<size_t>(width)};
-        packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)packet.frame_adrs);
+        packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)packet.frame_adrs, device_id_);
         if (SeparateYuvPlanes) {
             // get surface format
             OutputSurfaceInfo* p_surf_info;
@@ -191,7 +191,7 @@ py::object PyRocVideoDecoderCpu::PyGetFrameYuv(PyPacketData& packet, bool Separa
                 if (p_surf_info->surface_format == rocDecVideoSurfaceFormat_NV12 || p_surf_info->surface_format == rocDecVideoSurfaceFormat_P016) {
                     std::vector<size_t> shape{ static_cast<size_t>(height >> 1), static_cast<size_t>(width)};
                     uintptr_t uv_offset = p_surf_info->output_pitch * p_surf_info->output_vstride; // count for possible padding
-                    packet.ext_buf[1]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)(packet.frame_adrs + uv_offset));
+                    packet.ext_buf[1]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)(packet.frame_adrs + uv_offset), device_id_);
                 } else {
                     cout << "surf fmt: " << p_surf_info->surface_format << " [not supported]" << "\n";
                 }
@@ -257,7 +257,7 @@ py::object PyRocVideoDecoderCpu::PyGetFrameRgb(PyPacketData& packet, int rgb_for
             std::string type_str(static_cast<const char*>("|u1"));
             std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width), 3}; // 3 rgb channels
             std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1, 0}; // python assumes same dim for both shape & strides
-            packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb);
+            packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb, device_id_);
         }
     }
     return py::cast(packet.frame_pts);


### PR DESCRIPTION
The device id for LoadDLPack was hard-coded to zero. In a multi-GPU environment, we need it to use the same device id on which the decoder is created.