### PR TITLE
Restrict use of ffmpeg decode to rocDecode > ver 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,25 @@ if(NOT FFMPEG_FOUND)
 endif()
 
 if(BUILD_ROCPYDECODE)
+    # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
+    if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "6" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
+        set(OVERHEAD_SUPPORT 1)
+    else()
+        set(OVERHEAD_SUPPORT 0)
+    endif()
+    # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
+    if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
+        set(CODEC_SUPPORTED_CHECK 1)
+    else()
+        set(CODEC_SUPPORTED_CHECK 0)
+    endif()
+    # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
+    if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "8" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
+        set(FFMPEG_DECODE 1)
+    else()
+        set(FFMPEG_DECODE 0)
+    endif()
+
     # HIP
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::device)
     # rocDecode
@@ -226,8 +245,18 @@ if(BUILD_ROCPYDECODE)
     include_directories(src)
 
     file(GLOB_RECURSE pyfiles pyRocVideoDecode/*.py pyRocVideoDecode/*.pyi)
-    file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.h)
-    file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.cpp)
+    if(FFMPEG_DECODE)
+        file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.h)
+        file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.cpp)
+    else()
+        file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h)
+        file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp)
+
+        # Exclude ffmpeg files if not supported in this version
+        list(REMOVE_ITEM include src/roc_pyvideodecodecpu.h)
+        list(REMOVE_ITEM sources src/roc_pyvideodecodecpu.cpp)
+        list(REMOVE pyfiles pyRocVideoDecode/decodercpu.py)
+    endif()
 
     message("-- ${White}rocPyDecode -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
     message("-- ${White}rocPyDecode -- CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}${ColourReset}")
@@ -299,18 +328,10 @@ if(BUILD_ROCPYDECODE)
                 # include
                 target_include_directories(${TARGET_NAME_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIR})
 
-                # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
-                if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "6" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT=1)
-                else()
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT=0)
-                endif()
-                # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
-                if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK=1)
-                else()
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK=0)
-                endif()
+                # set target_compile_definitions
+                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT)
+                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK)
+                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC FFMPEG_DECODE)
 
                 foreach (filename ${pyfiles})
                     get_filename_component(target "${filename}" REALPATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,6 @@ if(BUILD_ROCPYDECODE)
                 # set target_compile_definitions
                 target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT)
                 target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK)
-                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC FFMPEG_DECODE)
 
                 foreach (filename ${pyfiles})
                     get_filename_component(target "${filename}" REALPATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,18 +245,8 @@ if(BUILD_ROCPYDECODE)
     include_directories(src)
 
     file(GLOB_RECURSE pyfiles pyRocVideoDecode/*.py pyRocVideoDecode/*.pyi)
-    if(FFMPEG_DECODE)
-        file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.h)
-        file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.cpp)
-    else()
-        file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h)
-        file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp)
-
-        # Exclude ffmpeg files if not supported in this version
-        list(REMOVE_ITEM include src/roc_pyvideodecodecpu.h)
-        list(REMOVE_ITEM sources src/roc_pyvideodecodecpu.cpp)
-        list(REMOVE pyfiles pyRocVideoDecode/decodercpu.py)
-    endif()
+    file(GLOB_RECURSE include src/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.h)
+    file(GLOB_RECURSE sources src/*.cpp  ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.cpp)
 
     message("-- ${White}rocPyDecode -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
     message("-- ${White}rocPyDecode -- CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}${ColourReset}")
@@ -331,6 +321,7 @@ if(BUILD_ROCPYDECODE)
                 # set target_compile_definitions
                 target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT)
                 target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK)
+                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC FFMPEG_DECODE)
 
                 foreach (filename ${pyfiles})
                     get_filename_component(target "${filename}" REALPATH)

--- a/src/roc_pyvideodecodecpu.cpp
+++ b/src/roc_pyvideodecodecpu.cpp
@@ -19,7 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
+#if FFMPEG_DECODE
 #include "roc_pyvideodecodecpu.h"
 #include "colorspace_kernels.h"
 #include "resize_kernels.h"
@@ -421,3 +421,4 @@ py::object PyRocVideoDecoderCpu::PyGetDecoderSessionOverHead(int session_id) {
 }
 
 #endif
+#endif // FFMPEG_DECODE

--- a/src/roc_pyvideodecodecpu.h
+++ b/src/roc_pyvideodecodecpu.h
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
-
+#if FFMPEG_DECODE
 #include "roc_video_dec.h"
 #include "roc_pydecode.h"
 #include "video_post_process.h"
@@ -123,3 +123,4 @@ class PyRocVideoDecoderCpu : public FFMpegVideoDecoder {
         size_t resized_image_size_in_bytes = 0;
         OutputSurfaceInfo *resized_surf_info = nullptr;
 };
+#endif // FFMPEG_DECODE


### PR DESCRIPTION
If rocDecode version less than 0.8.0 there will be no ffmpeg source code included in the build cpp, H and PY APIs as well.
The build will not include those files, therefor if they are not available there will be no errors.