### PR TITLE
Bug fix for ticket SWDEV-513010

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,12 @@ if(BUILD_ROCPYDECODE)
                 else()
                     target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK=0)
                 endif()
-
+                # FFMPEG multi-version support
+                if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=0)
+                else()
+                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
+                endif()
                 foreach (filename ${pyfiles})
                     get_filename_component(target "${filename}" REALPATH)
                     #to maintain folder structure


### PR DESCRIPTION
Fix for ticket:  https://ontrack-internal.amd.com/browse/SWDEV-513010

I noticed on the systems that reported "fail" that the pre-requisites are NOT fulfilled, and some of those systems have issues that you can NOT install those prerequisites.

You MUST install the prerequisites to have successful build/install and runtime of rocPyDecode.