### PR TITLE
Using the new macro ROCDECODE_CHECK_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ if(BUILD_ROCPYDECODE)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::device)
     # rocDecode
     include_directories(${ROCDECODE_INCLUDE_DIR}
+        ${ROCM_PATH}/include/rocdecode
         ${ROCM_PATH}/share/rocdecode/utils
         ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_LIBRARY})
@@ -298,19 +299,6 @@ if(BUILD_ROCPYDECODE)
                 target_link_libraries(${TARGET_NAME_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST})
                 # include
                 target_include_directories(${TARGET_NAME_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIR})
-
-                # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
-                if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "6" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT=1)
-                else()
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC OVERHEAD_SUPPORT=0)
-                endif()
-                # TODO: remove after ROCDECODE_CHECK_VERSION macro is pushed to mainline
-                if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK=1)
-                else()
-                    target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC CODEC_SUPPORTED_CHECK=0)
-                endif()
 
                 foreach (filename ${pyfiles})
                     get_filename_component(target "${filename}" REALPATH)

--- a/src/roc_pyvideodecode.cpp
+++ b/src/roc_pyvideodecode.cpp
@@ -48,8 +48,7 @@ void PyRocVideoDecoderInitializer(py::module& m) {
         .def("SetReconfigParams",&PyRocVideoDecoder::PySetReconfigParams)
         .def("IsCodecSupported",&PyRocVideoDecoder::PyCodecSupported)
         .def("GetBitDepth",&PyRocVideoDecoder::PyGetBitDepth)
-// TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
         .def("AddDecoderSessionOverHead",&PyRocVideoDecoder::PyAddDecoderSessionOverHead)
         .def("GetDecoderSessionOverHead",&PyRocVideoDecoder::PyGetDecoderSessionOverHead)
 #endif
@@ -395,11 +394,7 @@ py::int_ PyRocVideoDecoder::PyGetStride() {
 
 // for python binding
 py::object PyRocVideoDecoder::PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth) {
-#if CODEC_SUPPORTED_CHECK
     bool ret = CodecSupported(device_id, codec_id, bit_depth);
-#else
-    bool ret = true; // TODO: remove the whole #if CODEC_SUPPORTED_CHECK directive when ROCM 6.3 is public, only keep CodecSupported()
-#endif
     return py::cast(ret);
 }
 
@@ -407,8 +402,7 @@ uint32_t PyRocVideoDecoder::PyGetBitDepth() {
     return GetBitDepth();
 }
 
-// TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
 // for python binding, Session overhead refers to decoder initialization and deinitialization time
 py::object PyRocVideoDecoder::PyAddDecoderSessionOverHead(int session_id, double duration) {
     AddDecoderSessionOverHead(static_cast<std::thread::id>(session_id), duration);

--- a/src/roc_pyvideodecode.h
+++ b/src/roc_pyvideodecode.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "roc_video_dec.h"
 #include "roc_pydecode.h"
 #include "video_post_process.h"
+#include "rocdecode_version.h"
 
 typedef enum ReconfigFlushMode_enum {
     RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
@@ -101,7 +102,7 @@ class PyRocVideoDecoder : public RocVideoDecoder {
 
         uint32_t PyGetBitDepth();
 
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
         // Session overhead refers to decoder initialization and deinitialization time
         py::object PyAddDecoderSessionOverHead(int session_id, double duration);
         py::object PyGetDecoderSessionOverHead(int session_id);

--- a/src/roc_pyvideodecodecpu.cpp
+++ b/src/roc_pyvideodecodecpu.cpp
@@ -48,8 +48,7 @@ void PyRocVideoDecoderCpuInitializer(py::module& m) {
         .def("SetReconfigParams",&PyRocVideoDecoderCpu::PySetReconfigParams)
         .def("IsCodecSupported",&PyRocVideoDecoderCpu::PyCodecSupported)
         .def("GetBitDepth",&PyRocVideoDecoderCpu::PyGetBitDepth)
-// TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
         .def("AddDecoderSessionOverHead",&PyRocVideoDecoderCpu::PyAddDecoderSessionOverHead)
         .def("GetDecoderSessionOverHead",&PyRocVideoDecoderCpu::PyGetDecoderSessionOverHead)
 #endif
@@ -395,11 +394,7 @@ py::int_ PyRocVideoDecoderCpu::PyGetStride() {
 
 // for python binding
 py::object PyRocVideoDecoderCpu::PyCodecSupported(int device_id, rocDecVideoCodec codec_id, uint32_t bit_depth) {
-#if CODEC_SUPPORTED_CHECK
     bool ret = CodecSupported(device_id, codec_id, bit_depth);
-#else
-    bool ret = true; // TODO: remove the whole #if CODEC_SUPPORTED_CHECK directive when ROCM 6.3 is public, only keep CodecSupported()
-#endif
     return py::cast(ret);
 }
 
@@ -407,8 +402,7 @@ uint32_t PyRocVideoDecoderCpu::PyGetBitDepth() {
     return GetBitDepth();
 }
 
-// TODO: Change after merging with mainline #if ROCDECODE_CHECK_VERSION(0,6,0)
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
 // for python binding, Session overhead refers to decoder initialization and deinitialization time
 py::object PyRocVideoDecoderCpu::PyAddDecoderSessionOverHead(int session_id, double duration) {
     AddDecoderSessionOverHead(static_cast<std::thread::id>(session_id), duration);

--- a/src/roc_pyvideodecodecpu.h
+++ b/src/roc_pyvideodecodecpu.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "roc_pydecode.h"
 #include "video_post_process.h"
 #include "ffmpegvideodecode/ffmpeg_video_dec.h"
+#include "rocdecode_version.h"
 
 typedef enum ReconfigFlushMode_enum {
     RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
@@ -100,7 +101,7 @@ class PyRocVideoDecoderCpu : public FFMpegVideoDecoder {
 
         uint32_t PyGetBitDepth();
 
-#if OVERHEAD_SUPPORT
+#if ROCDECODE_CHECK_VERSION(0,6,0)
         // Session overhead refers to decoder initialization and deinitialization time
         py::object PyAddDecoderSessionOverHead(int session_id, double duration);
         py::object PyGetDecoderSessionOverHead(int session_id);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,23 +125,19 @@ if(Python3_FOUND AND ROCPYDECODE_PYBIND_SCRIPTS)
   )
   set_property(TEST video_decode_perf_python_H264 PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
   # 10 - video_decode_python_AV1 test
-  if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "7" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-    add_test(NAME video_decode_python_AV1
-        COMMAND ${Python3_EXECUTABLE} ${ROCM_PATH}/lib/pyRocVideoDecode/samples/videodecode.py
-        -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    set_property(TEST video_decode_python_AV1 PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
-  endif()
+  add_test(NAME video_decode_python_AV1
+      COMMAND ${Python3_EXECUTABLE} ${ROCM_PATH}/lib/pyRocVideoDecode/samples/videodecode.py
+      -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_property(TEST video_decode_python_AV1 PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
   # 11 - video_decode_python_AV9 test
-  if(${ROCDECODE_VER_MAJOR} VERSION_GREATER_EQUAL "0" AND ${ROCDECODE_VER_MINOR} VERSION_GREATER_EQUAL "10" AND ${ROCDECODE_VER_MICRO} VERSION_GREATER_EQUAL "0")
-    add_test(NAME video_decode_python_AV9
-        COMMAND ${Python3_EXECUTABLE} ${ROCM_PATH}/lib/pyRocVideoDecode/samples/videodecode.py
-        -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    set_property(TEST video_decode_python_AV9 PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
-  endif()
+  add_test(NAME video_decode_python_AV9
+      COMMAND ${Python3_EXECUTABLE} ${ROCM_PATH}/lib/pyRocVideoDecode/samples/videodecode.py
+      -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_property(TEST video_decode_python_AV9 PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 else()
   if(NOT Python3_FOUND)
     message("-- NOTE: ${PROJECT_NAME} requires Python3 - NOT FOUND")


### PR DESCRIPTION
Removing lines from CMakeLists that are using deprecated variables from rocDecode.
Using ROCDECODE_CHECK_VERSION macro instead in the source files. 