### PR TITLE
Docs - updated wording around supported linux environments

### DIFF
--- a/docs/install/rocPyDecode-prerequisites.rst
+++ b/docs/install/rocPyDecode-prerequisites.rst
@@ -6,7 +6,9 @@
 rocPyDecode prerequisites
 ********************************************************************
 
-rocPyDecode requires Ubuntu 22.04 or 24.04 with ROCm running on `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
+rocPyDecode has been tested on Ubuntu 22.04 or 24.04 with ROCm running on `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
+
+See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 
 ROCm needs to be installed using the `AMDGPU installer <https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.4.1/install/install-methods/amdgpu-installer-index.html>`_ with the ``rocm`` usecase:
 

--- a/docs/install/rocPyDecode-prerequisites.rst
+++ b/docs/install/rocPyDecode-prerequisites.rst
@@ -6,7 +6,8 @@
 rocPyDecode prerequisites
 ********************************************************************
 
-rocPyDecode has been tested on Ubuntu 22.04 or 24.04 with ROCm running on `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
+rocPyDecode has been tested on Ubuntu 22.04 and 24.04 with ROCm running on `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
+
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 


### PR DESCRIPTION
## Motivation

Need to make clear that rocPyDecode has only been tested on a subset of supported linux environments