### PR TITLE
removed amdgpu requirement and fixed two small issues

### DIFF
--- a/docs/install/rocPyDecode-install.rst
+++ b/docs/install/rocPyDecode-install.rst
@@ -16,7 +16,7 @@ The develop branch is the default rocPyDecode branch. The develop branch is inte
 
 rocPyDecode is installed with :doc:`CMake <./rocPyDecode-cmake-install>`. 
 
-Cmake can be used to created deb files and zipped tar files for distribution. :doc:`Wheel distribution files can also be created <../how-to/rocPyDecode-wheel>`.
+Cmake can be used to created deb files and zipped tar files for distribution. :doc:`Wheel distribution files <../how-to/rocPyDecode-wheel>` can also be created.
 
 The pip installation method can be used to generate Python egg and wheel files for distribution. 
 

--- a/docs/install/rocPyDecode-install.rst
+++ b/docs/install/rocPyDecode-install.rst
@@ -16,7 +16,7 @@ The develop branch is the default rocPyDecode branch. The develop branch is inte
 
 rocPyDecode is installed with :doc:`CMake <./rocPyDecode-cmake-install>`. 
 
-Cmake can be used to created deb files and zipped tar files for distribution. :docs:`Wheel distribution files can also be created <../how-to/rocPyDecode-wheel>`
+Cmake can be used to created deb files and zipped tar files for distribution. :doc:`Wheel distribution files can also be created <../how-to/rocPyDecode-wheel>`
 
 The pip installation method can be used to generate Python egg and wheel files for distribution. 
 

--- a/docs/install/rocPyDecode-install.rst
+++ b/docs/install/rocPyDecode-install.rst
@@ -16,7 +16,7 @@ The develop branch is the default rocPyDecode branch. The develop branch is inte
 
 rocPyDecode is installed with :doc:`CMake <./rocPyDecode-cmake-install>`. 
 
-Cmake can be used to created deb files and zipped tar files for distribution. :doc:`Wheel distribution files can also be created <../how-to/rocPyDecode-wheel>`
+Cmake can be used to created deb files and zipped tar files for distribution. :doc:`Wheel distribution files can also be created <../how-to/rocPyDecode-wheel>`.
 
 The pip installation method can be used to generate Python egg and wheel files for distribution. 
 

--- a/docs/install/rocPyDecode-prerequisites.rst
+++ b/docs/install/rocPyDecode-prerequisites.rst
@@ -8,14 +8,7 @@ rocPyDecode prerequisites
 
 rocPyDecode has been tested on Ubuntu 22.04 and 24.04 with ROCm running on `GPUs based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
 
-
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
-
-ROCm needs to be installed using the `AMDGPU installer <https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.4.1/install/install-methods/amdgpu-installer-index.html>`_ with the ``rocm`` usecase:
-
-.. code:: shell
-
-  sudo amdgpu-install --usecase=rocm
     
 rocPyDecode has the following prerequisites:
 

--- a/docs/install/rocPyDecode-prerequisites.rst
+++ b/docs/install/rocPyDecode-prerequisites.rst
@@ -6,9 +6,9 @@
 rocPyDecode prerequisites
 ********************************************************************
 
-rocPyDecode has been tested on Ubuntu 22.04 and 24.04 with ROCm running on `GPUs based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
+rocPyDecode has been tested on Ubuntu 22.04 and 24.04.
 
-See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
+For supported codecs and hardware capabilities, see :doc:`../reference/rocPyDecode-codecs-and-hardware`. And see `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
     
 rocPyDecode has the following prerequisites:
 

--- a/docs/install/rocPyDecode-prerequisites.rst
+++ b/docs/install/rocPyDecode-prerequisites.rst
@@ -8,7 +8,7 @@ rocPyDecode prerequisites
 
 rocPyDecode has been tested on Ubuntu 22.04 and 24.04.
 
-For supported codecs and hardware capabilities, see :doc:`../reference/rocPyDecode-codecs-and-hardware`. And see `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
+For supported codecs and hardware capabilities, see :doc:`../reference/rocPyDecode-codecs-and-hardware`. See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
     
 rocPyDecode has the following prerequisites:
 
@@ -24,4 +24,5 @@ rocPyDecode has the following prerequisites:
 rocPyJpegDecode additionally requires `rocJPEG <https://rocm.docs.amd.com/projects/rocJPEG/en/latest/index.html>`_.
 
 All prerequisites except for rocJPEG are installed with the `rocPyDecode-requirements.py <https://github.com/ROCm/rocPyDecode/blob/develop/rocPyDecode-requirements.py>`_ script. 
+
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -25,7 +25,7 @@ subtrees:
   - file: how-to/rocPyDecode-wheel.rst
     title: Create a wheel file
 
-- caption: Tutorials
+- caption: Samples
   entries:
   - file: tutorials/rocPyDecode-samples 
     title: rocPyDecode samples

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -3,9 +3,6 @@ defaults:
   maxdepth: 6
 root: index
 subtrees:
-- entries:
-  - file: what-is-rocPyDecode.rst
-    title: What is rocPyDecode?
 
 - caption: Install
   entries:


### PR DESCRIPTION
## Motivation

The amdgpu installer is deprecated, and since rocPyDecode doesn't explicitly rely on rocm being installed with that installer, that requirement has been removed.