### PR TITLE
Adding Python Handling Changes in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourRe
 
 # Allow specifying a Python version via -D PYTHON_VERSION_SUGGESTED
 option(PYTHON_VERSION_SUGGESTED "Suggested Python version for installation" "")
-# Fixed Python version list (same as in rocAL_pybind)
+# Fixed Python version list
 set(PYTHON_VERSIONS "3.13" "3.12" "3.11" "3.10" "3.9" "3.8")
 if(PYTHON_VERSION_SUGGESTED AND NOT (PYTHON_VERSION_SUGGESTED STREQUAL ""))
     set(PYTHON_VERSIONS "${PYTHON_VERSION_SUGGESTED}")
@@ -148,7 +148,8 @@ find_package(dlpack REQUIRED)
 find_package(FFmpeg REQUIRED)
 
 # HIP
-set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::device)
+set(LINK_LIBRARY_LIST "")
+list(APPEND LINK_LIBRARY_LIST hip::device)
 # rocDecode
 include_directories(${rocdecode_INCLUDE_DIR}
     ${ROCM_PATH}/include/rocdecode
@@ -161,28 +162,30 @@ else()
     find_library(rocdecode_HOST_LIBRARY rocdecode-host PATHS ${ROCM_PATH}/lib)
 endif()
 
-set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
+list(APPEND LINK_LIBRARY_LIST rocdecode::rocdecode)
 if(rocdecode_HOST_LIBRARY)
-    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${rocdecode_HOST_LIBRARY})
+    list(APPEND LINK_LIBRARY_LIST ${rocdecode_HOST_LIBRARY})
     message(STATUS "rocdecode_HOST_LIBRARY found")
 else()
     message(FATAL_ERROR "Library rocdecode_HOST_LIBRARY not found!")
 endif()
 # FFMPEG
 include_directories(${AVUTIL_INCLUDE_DIR} ${AVCODEC_INCLUDE_DIR} ${AVFORMAT_INCLUDE_DIR})
-set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${FFMPEG_LIBRARIES})
+list(APPEND LINK_LIBRARY_LIST ${FFMPEG_LIBRARIES})
 # rocPyDecode 
 include_directories(src)
-file(GLOB pyfiles pyRocVideoDecode/*.py pyRocVideoDecode/*.pyi)
 file(GLOB include src/rocdecode/*.h src/common/*.h ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.h ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.h)
 file(GLOB sources src/rocdecode/*.cpp src/common/*.cpp ${ROCM_PATH}/share/rocdecode/utils/*.cpp ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/*.cpp ${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/*.cpp)
 # rocJPEG
 include_directories(${rocjpeg_INCLUDE_DIR} ${ROCM_PATH}/share/rocjpeg/samples)
-set(LINK_LIBRARY_LIST_JPEG ${LINK_LIBRARY_LIST_JPEG} hip::device rocjpeg::rocjpeg)
+set(LINK_LIBRARY_LIST_JPEG "")
+list(APPEND LINK_LIBRARY_LIST_JPEG hip::device rocjpeg::rocjpeg)
 
-file(GLOB pyfiles_jpeg pyRocJpegDecode/*.py pyRocJpegDecode/*.pyi)
 file(GLOB include_jpeg src/rocjpeg/*.h src/common/*.h)
 file(GLOB sources_jpeg src/rocjpeg/*.cpp src/common/*.cpp)
+
+set(LINK_LIBRARY_LIST_BASE ${LINK_LIBRARY_LIST})
+set(LINK_LIBRARY_LIST_JPEG_BASE ${LINK_LIBRARY_LIST_JPEG})
 
 message("-- ${White}rocPyDecode -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
 message("-- ${White}rocPyJPEG -- Link Libraries: ${LINK_LIBRARY_LIST_JPEG}${ColourReset}")
@@ -193,10 +196,6 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
 install(FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT runtime)
 install(FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR}-asan COMPONENT asan)
-
-# Install rocPyDecode pybind lib (fixed version list, CMake Python discovery)
-set(ROCPYDECODE_INSTALLED FALSE)
-set(PYTHON_INDEX 0)
 
 foreach(PY_VERSION ${PYTHON_VERSIONS})
     message(STATUS "Searching for Python version: ${PY_VERSION}")
@@ -226,16 +225,17 @@ foreach(PY_VERSION ${PYTHON_VERSIONS})
         continue()
     endif()
 
-    # Ensure we have a standard extension suffix (e.g., .cpython-312-x86_64-linux-gnu.so)
-    if(NOT Python3_EXTENSION_SUFFIX OR Python3_EXTENSION_SUFFIX STREQUAL "")
-        if(Python3_SOABI)
-            set(Python3_EXTENSION_SUFFIX ".${Python3_SOABI}.so")
-        else()
-            set(Python3_EXTENSION_SUFFIX ".so")
-        endif()
-    endif()
+    # Reset link lists so each Python build starts clean
+    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST_BASE})
+    set(LINK_LIBRARY_LIST_JPEG ${LINK_LIBRARY_LIST_JPEG_BASE})
 
-    math(EXPR PYTHON_INDEX "${PYTHON_INDEX} + 1")
+    # Get extension suffix via Python to support CMake 3.15 (Python3_SOABI appears in 3.17+)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+        OUTPUT_VARIABLE Python3_EXTENSION_SUFFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
     set(TARGET_NAME_VERSIONED "${TARGET_NAME}_${PY_VERSION}")
     set(TARGET_NAME_JPEG_VERSIONED "${TARGET_NAME_JPEG}_${PY_VERSION}")
 
@@ -257,20 +257,12 @@ foreach(PY_VERSION ${PYTHON_VERSIONS})
         target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
     endif()
 
-    foreach(filename ${pyfiles})
-        get_filename_component(target "${filename}" REALPATH)
-        file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
-        message(STATUS "Copying ${filename} to ${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}")
-        configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
-    endforeach(filename)
-
     set_target_properties(${TARGET_NAME_VERSIONED} PROPERTIES
         PREFIX ""
         SUFFIX "${Python3_EXTENSION_SUFFIX}"
         OUTPUT_NAME "${TARGET_NAME}"
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}")
 
-    set(ROCPYDECODE_INSTALLED TRUE)
     message(STATUS "Building and installing rocPyDecode for Python ${PY_VERSION}")
     install(TARGETS ${TARGET_NAME_VERSIONED} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
 
@@ -278,13 +270,6 @@ foreach(PY_VERSION ${PYTHON_VERSIONS})
     pybind11_add_module(${TARGET_NAME_JPEG_VERSIONED} MODULE ${sources_jpeg})
     target_link_libraries(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST_JPEG} ${Python3_LIBRARIES})
     target_include_directories(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS})
-
-    foreach(filename ${pyfiles_jpeg})
-        get_filename_component(target "${filename}" REALPATH)
-        file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
-        message(STATUS "Copying ${filename} to ${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}")
-        configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
-    endforeach(filename)
 
     set_target_properties(${TARGET_NAME_JPEG_VERSIONED} PROPERTIES
         PREFIX ""
@@ -295,11 +280,6 @@ foreach(PY_VERSION ${PYTHON_VERSIONS})
     message(STATUS "Building and installing rocpyjpegdecode for Python ${PY_VERSION}")
     install(TARGETS ${TARGET_NAME_JPEG_VERSIONED} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
 endforeach()
-
-# Was rocPyDecode Installed?
-if(NOT ROCPYDECODE_INSTALLED)
-    message("-- ${Red}rocPyDecode wasn't installed, no python installation was found.${ColourReset}")
-endif()
 
 #install rocPyDecode API folder -and- samples folder
 install(DIRECTORY pyRocVideoDecode DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,20 +128,13 @@ message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourRe
 
 # Allow specifying a Python version via -D PYTHON_VERSION_SUGGESTED
 option(PYTHON_VERSION_SUGGESTED "Suggested Python version for installation" "")
-set(USER_DEFINED FALSE)
-if(NOT (PYTHON_VERSION_SUGGESTED STREQUAL OFF))
-    set(USER_DEFINED TRUE)
-    message("-- ${White}${USER_DEFINED} -- USER DEFINED PYTHON: ${PYTHON_VERSION_SUGGESTED}${ColourReset}")
+# Fixed Python version list (same as in rocAL_pybind)
+set(PYTHON_VERSIONS "3.13" "3.12" "3.11" "3.10" "3.9" "3.8")
+if(PYTHON_VERSION_SUGGESTED AND NOT (PYTHON_VERSION_SUGGESTED STREQUAL ""))
+    set(PYTHON_VERSIONS "${PYTHON_VERSION_SUGGESTED}")
+    message("-- ${White}USER DEFINED PYTHON VERSION LIST: ${PYTHON_VERSIONS}${ColourReset}")
 endif()
-
-# Allow specifying a Python version located on specific folder via -D PYTHON_FOLDER_SUGGESTED
-# This folder will be added to all other discovered python folders if 'USER_DEFINED' is FALSE
-option(PYTHON_FOLDER_SUGGESTED "Suggested Python version folder to include in the installation" "")
-set(USER_PY_FOLDER FALSE)
-if(NOT (PYTHON_FOLDER_SUGGESTED STREQUAL OFF))
-    set(USER_PY_FOLDER TRUE)
-    message("-- ${White}${USER_PY_FOLDER} -- USER DEFINED PYTHON FOLDER: ${PYTHON_FOLDER_SUGGESTED}${ColourReset}")
-endif()
+set(CMAKE_INSTALL_PREFIX_PYTHON ${CMAKE_INSTALL_PREFIX})
 
 # rocPyDecode build
 set(CMAKE_SKIP_BUILD_RPATH true)
@@ -153,23 +146,6 @@ find_package(rocjpeg 1.0.0 REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(dlpack REQUIRED)
 find_package(FFmpeg REQUIRED)
-
-# Search for all installed Python versions - exclude Python versions lower than 3.9
-execute_process(COMMAND bash -c "compgen -c | grep -E '^python3\.[0-9]+$' | awk -F. '$2 >= 9' | sort -Vru" OUTPUT_VARIABLE PYTHON_EXECUTABLES OUTPUT_STRIP_TRAILING_WHITESPACE)
-# Convert space-separated list to CMake list
-string(REPLACE "\n" ";" PYTHON_EXECUTABLES_LIST "${PYTHON_EXECUTABLES}")
-# Merge the user defined python folder if passed here
-if(USER_PY_FOLDER)
-    list(APPEND PYTHON_EXECUTABLES_LIST ${PYTHON_FOLDER_SUGGESTED})
-endif()
-# Check if the list is empty
-if(PYTHON_EXECUTABLES_LIST STREQUAL "")
-    set(Python3_FOUND FALSE)
-    message(WARNING "No Python versions found. Python3_FOUND set to FALSE.")
-else()
-    set(Python3_FOUND TRUE)
-    message(STATUS "Found Python versions: ${PYTHON_EXECUTABLES_LIST}")
-endif()
 
 # HIP
 set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::device)
@@ -218,128 +194,111 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
 install(FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT runtime)
 install(FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR}-asan COMPONENT asan)
 
-# Detect Conda Installation
-execute_process(COMMAND which conda OUTPUT_VARIABLE CONDA_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-set(CONDA_PYTHON_VERSIONS "")
-
-if(CONDA_EXECUTABLE)
-    message(STATUS "Conda detected at: ${CONDA_EXECUTABLE}")
-
-    # Extract Conda Python paths
-    execute_process(COMMAND bash -c "conda env list | awk 'NF && !/^#/ && $1 != \"base\" {print $1}'" OUTPUT_VARIABLE CONDA_ENV_NAMES OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    # Iterate through Conda environments to get its Python paths
-    foreach(ENV_NAME ${CONDA_ENV_NAMES})
-        # get conda py path
-        execute_process(COMMAND conda run -n ${ENV_NAME} which python OUTPUT_VARIABLE CONDA_PYTHON_EXEC OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-        if(NOT CONDA_PYTHON_EXEC STREQUAL "")
-            list(APPEND CONDA_PYTHON_VERSIONS ${CONDA_PYTHON_EXEC})
-            message(STATUS "Found Conda Python: ${CONDA_PYTHON_EXEC} in environment ${ENV_NAME}")
-        endif()
-    endforeach()
-else()
-    message(STATUS "No Conda installation detected.")
-endif()
-
-# Merge system and Conda Python versions
-list(APPEND PYTHON_EXECUTABLES_LIST ${CONDA_PYTHON_VERSIONS})
-
-#install rocPyDecode pybind lib
+# Install rocPyDecode pybind lib (fixed version list, CMake Python discovery)
 set(ROCPYDECODE_INSTALLED FALSE)
-if(NOT PYTHON_EXECUTABLES_LIST STREQUAL "")
+set(PYTHON_INDEX 0)
 
-    # Iterate through found Python versions and install rocPyDecode for each
-    set(PYTHON_INDEX 0)
-    foreach(PYTHON_VERSION ${PYTHON_EXECUTABLES_LIST})
+foreach(PY_VERSION ${PYTHON_VERSIONS})
+    message(STATUS "Searching for Python version: ${PY_VERSION}")
 
-        #Only the USER DEFINED python
-        if(USER_DEFINED)
-            string(FIND ${PYTHON_VERSION} ${PYTHON_VERSION_SUGGESTED} FOUND_INDEX)
-            if(${FOUND_INDEX} EQUAL -1)
-                continue()
-            endif()
-            message("-- ${BoldBlue}Installing ONLY for the user defined Python = ${PYTHON_VERSION_SUGGESTED}${ColourReset}")
-        endif()
+    foreach(v IN ITEMS
+        Python3_EXECUTABLE
+        Python3_VERSION
+        Python3_SOABI
+        Python3_EXTENSION_SUFFIX
+        Python3_Interpreter_FOUND
+        Python3_Development_FOUND
+        Python3_INCLUDE_DIRS
+        Python3_LIBRARY
+        Python3_LIBRARIES
+        Python3_STDARCH
+        Python3_FIND_IMPLEMENTATIONS
+    )
+        unset(${v} CACHE)
+        unset(${v})
+    endforeach()
 
-        # python full path
-        execute_process(COMMAND which ${PYTHON_VERSION} OUTPUT_VARIABLE CURRENT_PY_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-        # if exist do the install
-        if(EXISTS ${CURRENT_PY_EXECUTABLE})
-            # Increment counter
-            math(EXPR PYTHON_INDEX "${PYTHON_INDEX} + 1")
-            # Use an incremental number
-            set(TARGET_NAME_VERSIONED "${TARGET_NAME}.${PYTHON_INDEX}")
-            # Find python
-            find_package(Python QUIET COMPONENTS Interpreter Development)
-            # Extract Python include directory - very important for targeting appropriate python interpeter during compilation
-            execute_process(COMMAND ${CURRENT_PY_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('include'))" OUTPUT_VARIABLE PYTHON_INCLUDE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-            #add-rocPyDecode-pybind11-module
-            pybind11_add_module(${TARGET_NAME_VERSIONED} MODULE ${sources})
-            target_link_libraries(${TARGET_NAME_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST})
+    set(Python3_FIND_VIRTUALENV FIRST)
+    find_package(Python3 "${PY_VERSION}" EXACT QUIET COMPONENTS Interpreter Development)
 
-            # include
-            target_include_directories(${TARGET_NAME_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIR})
+    if(NOT Python3_FOUND)
+        message("-- ${Yellow}NOTE: Python${PY_VERSION} Not Found, not building rocPyDecode for Python${PY_VERSION}${ColourReset}")
+        continue()
+    endif()
 
-            # FFMPEG multi-version support
-            if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
-                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=0)
-            else()
-                target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
-            endif()
-
-            foreach(filename ${pyfiles})
-                get_filename_component(target "${filename}" REALPATH)
-                #to maintain folder structure
-                file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
-                message(STATUS "Copying ${filename} to ${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}")
-                configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
-            endforeach(filename)
-            #Get this python .so file extension (full name)
-            execute_process(COMMAND ${CURRENT_PY_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))" OUTPUT_VARIABLE PYTHON_MODULE_EXTENSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-            set_target_properties(${TARGET_NAME_VERSIONED} PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}" SUFFIX "${PYTHON_MODULE_EXTENSION}" LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}")
-            set(NAME_SRC_VIDEO ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}/${PYTHON_MODULE_PREFIX}${TARGET_NAME_VERSIONED}${PYTHON_MODULE_EXTENSION})
-            set(NAME_DST_VIDEO ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}/${PYTHON_MODULE_PREFIX}${TARGET_NAME}${PYTHON_MODULE_EXTENSION})
-            # Add a custom command to rename the shared library only after it's built
-            add_custom_command(TARGET ${TARGET_NAME_VERSIONED} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${NAME_SRC_VIDEO} ${NAME_DST_VIDEO} COMMENT "Renaming shared library after build: ${NAME_SRC_VIDEO} -> ${NAME_DST_VIDEO}" VERBATIM)
-            #install .so
-            set(ROCPYDECODE_INSTALLED TRUE)
-            message(STATUS "Building and installing rocPyDecode for ${PYTHON_VERSION}")
-            install(FILES ${NAME_DST_VIDEO} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
-
-
-            set(TARGET_NAME_JPEG_VERSIONED "${TARGET_NAME_JPEG}.${PYTHON_INDEX}")
-            #add-rocpyjpegdecode-pybind11-module
-            pybind11_add_module(${TARGET_NAME_JPEG_VERSIONED} MODULE ${sources_jpeg})
-            target_link_libraries(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST_JPEG})
-
-            #include
-            target_include_directories(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIR})
-            foreach(filename ${pyfiles_jpeg})
-                get_filename_component(target "${filename}" REALPATH)
-                #to maintain folder structure
-                file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
-                message(STATUS "Copying ${filename} to ${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}")
-                configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
-            endforeach(filename)
-            set_target_properties(${TARGET_NAME_JPEG_VERSIONED} PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}" SUFFIX "${PYTHON_MODULE_EXTENSION}" LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG}/${CMAKE_INSTALL_LIBDIR}")
-            set(NAME_SRC_JPEG ${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG}/${CMAKE_INSTALL_LIBDIR}/${PYTHON_MODULE_PREFIX}${TARGET_NAME_JPEG_VERSIONED}${PYTHON_MODULE_EXTENSION})
-            set(NAME_DST_JPEG ${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG}/${CMAKE_INSTALL_LIBDIR}/${PYTHON_MODULE_PREFIX}${TARGET_NAME_JPEG}${PYTHON_MODULE_EXTENSION})
-            add_custom_command(TARGET ${TARGET_NAME_JPEG_VERSIONED} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${NAME_SRC_JPEG} ${NAME_DST_JPEG} COMMENT "Renaming shared library after build: ${NAME_SRC_JPEG} -> ${NAME_DST_JPEG}" VERBATIM)
-            message(STATUS "Building and installing rocpyjpegdecode for ${PYTHON_VERSION}")
-            install(FILES ${NAME_DST_JPEG} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
+    # Ensure we have a standard extension suffix (e.g., .cpython-312-x86_64-linux-gnu.so)
+    if(NOT Python3_EXTENSION_SUFFIX OR Python3_EXTENSION_SUFFIX STREQUAL "")
+        if(Python3_SOABI)
+            set(Python3_EXTENSION_SUFFIX ".${Python3_SOABI}.so")
         else()
-            message(STATUS "[Python Version DOES NOT EXIST] :${PYTHON_VERSION}")
-        endif() # (EXISTS ${CURRENT_PY_EXECUTABLE})
-    endforeach() # (PYTHON_VERSION ${PYTHON_EXECUTABLES_LIST})
-endif() # (NOT PYTHON_EXECUTABLES_LIST STREQUAL "")
+            set(Python3_EXTENSION_SUFFIX ".so")
+        endif()
+    endif()
+
+    math(EXPR PYTHON_INDEX "${PYTHON_INDEX} + 1")
+    set(TARGET_NAME_VERSIONED "${TARGET_NAME}_${PY_VERSION}")
+    set(TARGET_NAME_JPEG_VERSIONED "${TARGET_NAME_JPEG}_${PY_VERSION}")
+
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX_PYTHON ${Python3_STDARCH} CACHE PATH "rocPyDecode Python install path" FORCE)
+    else()
+        set(CMAKE_INSTALL_PREFIX_PYTHON ${CMAKE_INSTALL_PREFIX} CACHE PATH "rocPyDecode Python install path" FORCE)
+    endif()
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+    # Build rocPyDecode module for this Python version
+    pybind11_add_module(${TARGET_NAME_VERSIONED} MODULE ${sources})
+    target_link_libraries(${TARGET_NAME_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST} ${Python3_LIBRARIES})
+    target_include_directories(${TARGET_NAME_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS})
+
+    if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+        target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=0)
+    else()
+        target_compile_definitions(${TARGET_NAME_VERSIONED} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
+    endif()
+
+    foreach(filename ${pyfiles})
+        get_filename_component(target "${filename}" REALPATH)
+        file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
+        message(STATUS "Copying ${filename} to ${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}")
+        configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
+    endforeach(filename)
+
+    set_target_properties(${TARGET_NAME_VERSIONED} PROPERTIES
+        PREFIX ""
+        SUFFIX "${Python3_EXTENSION_SUFFIX}"
+        OUTPUT_NAME "${TARGET_NAME}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME}/${CMAKE_INSTALL_LIBDIR}")
+
+    set(ROCPYDECODE_INSTALLED TRUE)
+    message(STATUS "Building and installing rocPyDecode for Python ${PY_VERSION}")
+    install(TARGETS ${TARGET_NAME_VERSIONED} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
+
+    # Build rocPyJpegDecode module for this Python version
+    pybind11_add_module(${TARGET_NAME_JPEG_VERSIONED} MODULE ${sources_jpeg})
+    target_link_libraries(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${LINK_LIBRARY_LIST_JPEG} ${Python3_LIBRARIES})
+    target_include_directories(${TARGET_NAME_JPEG_VERSIONED} PRIVATE ${pybind11_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS})
+
+    foreach(filename ${pyfiles_jpeg})
+        get_filename_component(target "${filename}" REALPATH)
+        file(RELATIVE_PATH ITEM_PATH_REL ${CMAKE_CURRENT_SOURCE_DIR} ${filename})
+        message(STATUS "Copying ${filename} to ${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}")
+        configure_file("${filename}" "${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG_VERSIONED}/${ITEM_PATH_REL}" COPYONLY)
+    endforeach(filename)
+
+    set_target_properties(${TARGET_NAME_JPEG_VERSIONED} PROPERTIES
+        PREFIX ""
+        SUFFIX "${Python3_EXTENSION_SUFFIX}"
+        OUTPUT_NAME "${TARGET_NAME_JPEG}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${TARGET_NAME_JPEG}/${CMAKE_INSTALL_LIBDIR}")
+
+    message(STATUS "Building and installing rocpyjpegdecode for Python ${PY_VERSION}")
+    install(TARGETS ${TARGET_NAME_JPEG_VERSIONED} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
+endforeach()
 
 # Was rocPyDecode Installed?
 if(NOT ROCPYDECODE_INSTALLED)
-    if(USER_DEFINED)
-        message("-- ${Red}rocPyDecode wasn't installed, user defined python version ${PYTHON_VERSION_SUGGESTED} was not found.${ColourReset}")
-    else()
-        message("-- ${Red}rocPyDecode wasn't installed, no python installation was found.${ColourReset}")
-    endif()
+    message("-- ${Red}rocPyDecode wasn't installed, no python installation was found.${ColourReset}")
 endif()
 
 #install rocPyDecode API folder -and- samples folder

--- a/samples/rocjpeg/jpegdecode.py
+++ b/samples/rocjpeg/jpegdecode.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import torch
 import pyRocJpegDecode.decoder as jdec
 import rocpyjpegdecode.jpegTypes as jpegt
 import argparse
@@ -54,11 +53,10 @@ def jpeg_decode(
 
     print(f"Decoding file: {input_file_path} is complete.\n")
 
-    # example how to save the decoded image as a file
+    # example how to save the decoded image as a file (.png)
     if (output_file_path is not None):
         filename = output_file_path.strip() + ".png"
-        img1 = torch.from_numpy(img_tensor.to_numpy())
-        arr = img1.cpu().numpy()
+        arr = img_tensor.to_numpy()
         img = Image.fromarray(arr.astype(np.uint8))
         img.save(filename)
         print(f"Image saved as: {filename}")

--- a/samples/rocjpeg/jpegdecode.py
+++ b/samples/rocjpeg/jpegdecode.py
@@ -21,10 +21,126 @@
 import pyRocJpegDecode.decoder as jdec
 import rocpyjpegdecode.jpegTypes as jpegt
 import argparse
+import ctypes
 import os
 import sys
-from PIL import Image
-import numpy as np
+
+_capsule_get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
+_capsule_get_pointer.restype = ctypes.c_void_p
+_capsule_get_pointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [("code", ctypes.c_uint8), ("bits", ctypes.c_uint8), ("lanes", ctypes.c_uint16)]
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+class _DLManagedTensor(ctypes.Structure):
+    _fields_ = [
+        ("dl_tensor", _DLTensor),
+        ("manager_ctx", ctypes.c_void_p),
+        ("deleter", ctypes.c_void_p),
+    ]
+
+
+def _dlpack_bytes_and_shape(buffer_obj):
+    """Extract bytes, shape, and bit depth from a DLPack buffer without numpy/torch."""
+    capsule = buffer_obj.__dlpack__()
+    managed_ptr = _capsule_get_pointer(capsule, b"dltensor")
+    if not managed_ptr:
+        raise RuntimeError("Failed to acquire DLPack pointer from capsule")
+    managed = _DLManagedTensor.from_address(managed_ptr)
+    tensor = managed.dl_tensor
+    shape = [tensor.shape[i] for i in range(tensor.ndim)]
+    if not shape:
+        raise RuntimeError("Empty shape returned from DLTensor")
+    bit_depth = int(tensor.dtype.bits)
+    bytes_per_item = max((bit_depth + 7) // 8, 1)
+    total_items = 1
+    for dim in shape:
+        total_items *= dim
+    data_ptr = ctypes.c_void_p(tensor.data).value
+    if data_ptr is None:
+        raise RuntimeError("DLTensor data pointer is null")
+    data_ptr += int(tensor.byte_offset)
+    raw_bytes = ctypes.string_at(data_ptr, total_items * bytes_per_item)
+    return raw_bytes, shape, bit_depth
+
+
+def _tensor_to_interleaved_rgb(img_tensor, output_format):
+    planar_format = int(jpegt.RocJpegOutputFormat.ROCJPEG_OUTPUT_RGB_PLANAR)
+    bit_depth = None
+    bytes_per_sample = None
+    if output_format == planar_format:
+        planes = []
+        plane_shape = None
+        for idx in range(3):
+            plane_bytes, shape, bits = _dlpack_bytes_and_shape(img_tensor.ext_buf[idx])
+            if len(shape) < 2:
+                raise RuntimeError(f"Unexpected plane shape: {shape}")
+            if bit_depth is None:
+                bit_depth = bits
+                bytes_per_sample = max((bit_depth + 7) // 8, 1)
+            if plane_shape is None:
+                plane_shape = shape
+            elif plane_shape[0] != shape[0] or plane_shape[1] != shape[1]:
+                raise RuntimeError("RGB planes have mismatched dimensions")
+            if bits != bit_depth:
+                raise RuntimeError("RGB planes have mismatched bit depths")
+            planes.append(plane_bytes)
+        height, width = int(plane_shape[0]), int(plane_shape[1])
+        pixel_count = height * width
+        expected_plane_bytes = pixel_count * bytes_per_sample
+        for plane in planes:
+            if len(plane) < expected_plane_bytes:
+                raise RuntimeError("RGB plane buffer smaller than expected for given dimensions")
+        interleaved = bytearray(pixel_count * 3 * bytes_per_sample)
+        for i in range(pixel_count):
+            base = i * 3 * bytes_per_sample
+            offset = i * bytes_per_sample
+            interleaved[base:base + bytes_per_sample] = planes[0][offset:offset + bytes_per_sample]
+            interleaved[base + bytes_per_sample:base + 2 * bytes_per_sample] = planes[1][offset:offset + bytes_per_sample]
+            interleaved[base + 2 * bytes_per_sample:base + 3 * bytes_per_sample] = planes[2][offset:offset + bytes_per_sample]
+        return bytes(interleaved), width, height, bit_depth
+    else:
+        rgb_bytes, shape, bit_depth = _dlpack_bytes_and_shape(img_tensor.ext_buf[0])
+        if len(shape) < 3 or shape[2] < 3:
+            raise RuntimeError(f"Unexpected tensor shape for RGB output: {shape}")
+        height, width = int(shape[0]), int(shape[1])
+        bytes_per_sample = max((bit_depth + 7) // 8, 1)
+        expected = height * width * 3 * bytes_per_sample
+        if len(rgb_bytes) < expected:
+            raise RuntimeError("RGB buffer smaller than expected for given dimensions")
+        return rgb_bytes[:expected], width, height, bit_depth
+
+
+def _save_image_from_tensor(img_tensor, output_format, filename):
+    base_path = filename.strip()
+    dir_name = os.path.dirname(base_path)
+    root_name = os.path.splitext(os.path.basename(base_path))[0]
+    if not root_name:
+        root_name = "output"
+
+    rgb_bytes, width, height, bit_depth = _tensor_to_interleaved_rgb(img_tensor, output_format)
+    out_name = f"{root_name}_{width}x{height}_{bit_depth}bits.rgb"
+    output_path = os.path.join(dir_name, out_name) if dir_name else out_name
+
+    with open(output_path, "wb") as fh:
+        fh.write(rgb_bytes)
+
+    return output_path
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Example of decoding jpeg image
@@ -53,13 +169,11 @@ def jpeg_decode(
 
     print(f"Decoding file: {input_file_path} is complete.\n")
 
-    # example how to save the decoded image as a file (.png)
+    # example how to save the decoded image as a raw RGB file
     if (output_file_path is not None):
-        filename = output_file_path.strip() + ".png"
-        arr = img_tensor.to_numpy()
-        img = Image.fromarray(arr.astype(np.uint8))
-        img.save(filename)
-        print(f"Image saved as: {filename}")
+        filename = output_file_path.strip()
+        saved_path = _save_image_from_tensor(img_tensor, output_format, filename)
+        print(f"Raw RGB image saved as: {saved_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

# Python handling changes (in CMakeLists.txt)

- Switched to a fixed Python version list (3.13 -to- 3.8) with an optional `PYTHON_VERSION_SUGGESTED` override; `find_package(Python3 ... EXACT)` runs for each version.
- Removed executable/Conda scanning; Python detection now relies on CMake’s Python3 package per version in the list.
- For each found Python, build versioned module targets (`rocpydecode_<ver>`, `rocpyjpegdecode_<ver>`) using CMake-provided Python includes/libs.
- Module names use `PREFIX ""`, `OUTPUT_NAME` set to `rocpydecode`/`rocpyjpegdecode`, and `SUFFIX` from `Python3_EXTENSION_SUFFIX`, producing standard filenames like `rocpydecode.cpython-312-x86_64-linux-gnu.so`.
- Per-version installs are driven by `install(TARGETS ...)` directly on the versioned targets.

## Technical Details

Changes made in CMakeLists.txt

## Test Plan

build, install & ctest 

To test changes in the jpeg decode sample with:
_python3 samples/rocjpeg/jpegdecode.py -i /opt/rocm/share/rocjpeg/images/mug_420.jpg -fmt 3 -bk 0 -d 0 -o output_image_
later view the **output_image.png** on the local folder.

## Test Result

ALL PASS