### PR TITLE
Fix RGB DLPack strides in PyGetFrameRgb

### DIFF
--- a/src/rocdecode/roc_pyvideodecode.cpp
+++ b/src/rocdecode/roc_pyvideodecode.cpp
@@ -255,7 +255,7 @@ py::object PyRocVideoDecoder::PyGetFrameRgb(PyPacketData& packet, int rgb_format
             uint32_t bit_depth = GetBitDepth();
             std::string type_str(static_cast<const char*>("|u1"));
             std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width), 3}; // 3 rgb channels
-            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1, 0}; // python assumes same dim for both shape & strides
+            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 3, 1}; // bytes per row, per pixel, per channel
             packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb, device_id_);
         }
     }

--- a/src/rocdecode/roc_pyvideodecodecpu.cpp
+++ b/src/rocdecode/roc_pyvideodecodecpu.cpp
@@ -202,7 +202,7 @@ py::object PyRocVideoDecoderCpu::PyGetFrameRgb(PyPacketData& packet, int rgb_for
             uint32_t bit_depth = GetBitDepth();
             std::string type_str(static_cast<const char*>("|u1"));
             std::vector<size_t> shape{ static_cast<size_t>(height), static_cast<size_t>(width), 3}; // 3 rgb channels
-            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 1, 0}; // python assumes same dim for both shape & strides
+            std::vector<size_t> stride{ static_cast<size_t>(surf_stride), 3, 1}; // bytes per row, per pixel, per channel
             packet.ext_buf[0]->LoadDLPack(shape, stride, bit_depth, type_str, (void *)frame_ptr_rgb, device_id_);
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -372,3 +372,13 @@ if(RUN_ROCPYJPEG_TESTS)
     set_property(TEST jpeg_decode_batched_python PROPERTY ENVIRONMENT "PYTHONPATH=${ROCPYJPEG_PYTHONPATH}:$PYTHONPATH")
   endif()
 endif()
+
+if(RUN_ROCPYDECODE_TESTS AND ROCPYDECODE_USE_FFMPEG)
+  # 19 - decoder rgb dlpack test
+  add_test(NAME rocpydecode_test_decoder_rgb_dlpack
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/decoder_rgb_dlpack_test.py
+    -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_property(TEST rocpydecode_test_decoder_rgb_dlpack PROPERTY ENVIRONMENT "PYTHONPATH=${ROCPYDECODE_PYTHONPATH}:$PYTHONPATH")
+endif()

--- a/tests/decoder_rgb_dlpack_test.py
+++ b/tests/decoder_rgb_dlpack_test.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pyRocVideoDecode.demuxer as dmx
+import pyRocVideoDecode.decoder as dec
+from pyRocVideoDecode.types import OUT_SURFACE_MEM_DEV_COPIED
+import argparse
+import sys
+
+
+def test_rgb_dlpack(input_file_path):
+    demuxer = dmx.demuxer(input_file_path)
+    codec_id = dec.GetRocDecCodecID(demuxer.GetCodecId())
+    decoder = dec.decoder(codec_id, mem_type=OUT_SURFACE_MEM_DEV_COPIED, b_force_zero_latency=True)
+
+    while True:
+        packet = demuxer.DemuxFrame()
+        for i in range(decoder.DecodeFrame(packet)):
+            if decoder.GetFrameRgb(packet, rgb_format=3) == -1:
+                continue
+
+            # interleaved 8-bit RGB surface: shape [H, W, 3], 3 bytes/pixel, 1 byte/channel.
+            buf = packet.ext_buf[0]
+            assert buf.dtype == "|u1" # unsigned 8-bit integer, "|u1" == uint8
+            assert len(buf.shape) == 3 and buf.shape[2] == 3
+            assert buf.strides[1:] == (3, 1)
+
+            decoder.ReleaseFrame(packet)
+            print('rocPyDecode RGB DLPack test finished.')
+            return
+
+        if packet.bitstream_size <= 0:
+            break
+
+    raise RuntimeError('no RGB frame decoded')
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='PyRocDecode RGB DLPack Test Arguments')
+    parser.add_argument(
+        '-i',
+        '--input',
+        type=str,
+        help='Input File Path - required',
+        required=True)
+    try:
+        args = parser.parse_args()
+    except SystemExit as e:
+        print(f"Error: {e}. Please check the input arguments and try again.")
+        sys.exit(1)
+
+    input_file_path = args.input
+
+    test_rgb_dlpack(input_file_path)


### PR DESCRIPTION
## Motivation

`torch.from_dlpack(packet.ext_buf[0])` after `decoder.GetFrameRgb(packet, rgb_format=3)` returns a grayscale tensor clipped to the left 1/3 of the frame instead of the full color image. Any consumer that honors DLPack metadata (PyTorch, CuPy, JAX, `numpy.from_dlpack`, ...) is affected, which breaks GPU-resident decode → inference pipelines.

## Technical Details

Root cause: byte-strides emitted by `PyGetFrameRgb` for an `[H, W, 3]` uint8 RGB surface are `(W*3, 1, 0)`. Correct strides are `(W*3, 3, 1)` — bytes-per-row, bytes-per-pixel, bytes-per-channel. 

Same frame, decoded with the same code, before and after this PR:
<img width="1620" height="450" alt="image" src="https://github.com/user-attachments/assets/e7f72a58-9f3c-4170-8be6-1ce1de662ee2" />

Two-line fix in both backends:
```cpp
// before
std::vector<size_t> stride{ surf_stride, 1, 0 };
// after
std::vector<size_t> stride{ surf_stride, 3, 1 };
```

Files touched:
- [`src/rocdecode/roc_pyvideodecode.cpp`](https://github.com/ROCm/rocPyDecode/blob/develop/src/rocdecode/roc_pyvideodecode.cpp) (GPU backend)
- [`src/rocdecode/roc_pyvideodecodecpu.cpp`](https://github.com/ROCm/rocPyDecode/blob/develop/src/rocdecode/roc_pyvideodecodecpu.cpp) (CPU backend)

## Test Plan

**1. Reproducing the screenshots.** Decode the first RGB frame and save it as a PNG using DLPack metadata as-is:

```python
# repro.py
import sys, torch, numpy as np
from PIL import Image
import pyRocVideoDecode.demuxer as dmx
import pyRocVideoDecode.decoder as dec
from pyRocVideoDecode.types import OUT_SURFACE_MEM_DEV_COPIED

demuxer = dmx.demuxer(sys.argv[1])
decoder = dec.decoder(
    dec.GetRocDecCodecID(demuxer.GetCodecId()),
    mem_type=OUT_SURFACE_MEM_DEV_COPIED, b_force_zero_latency=True)

while True:
    packet = demuxer.DemuxFrame()
    for _ in range(decoder.DecodeFrame(packet)):
        if decoder.GetFrameRgb(packet, rgb_format=3) == -1:
            continue
        buf = packet.ext_buf[0]
        print("strides =", tuple(buf.strides))   # (W*3, 1, 0) on master, (W*3, 3, 1) after the fix
        arr = np.ascontiguousarray(torch.from_dlpack(buf).cpu().numpy())
        Image.fromarray(arr).save(sys.argv[2])
        sys.exit()
    if packet.bitstream_size <= 0: break
```

```bash
PYTHONPATH=/opt/rocm/lib python3 repro.py \
    /opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 frame.png
```

**2. Regression test.** New `tests/decoder_rgb_dlpack_test.py` asserts `shape`, `strides`, `dtype` on `BufferInterface` directly (no torch dependency, follows the style of `demuxer_test.py` / `decoder_test.py`). 


## Test Result

| Build | `repro.py` strides | `repro.py` PNG | `decoder_rgb_dlpack_test.py` |
|---|---|---|---|
| master (buggy) | `(6144, 1, 0)` | grayscale, clipped to 1/3 width | `AssertionError: buf.strides[1:] == (3, 1)` |
| this PR | `(6144, 3, 1)` | correct color frame | passes (`exit 0`) |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


### Out of scope (deliberately not fixed in this PR)
This PR only addresses the **interleaved 8-bit RGB/BGR** code path of `GetFrameRgb` (`rgb_format` = `rgb` / `bgr`).
 **Other RGB output formats in `PyGetFrameRgb`.** The function still hard-codes `shape = [H, W, 3]` and `dtype = "|u1"` regardless of the requested format, so `rgba`/`bgra` (4 channels), `rgb48`/`bgr48` (16-bit), and `rgba64`/`bgra64` are still mis-described in DLPack metadata. Fixing them needs a small refactor, not a one-line change 

